### PR TITLE
Enhance 404 page template with consistent design patterns

### DIFF
--- a/woostarter/patterns/hidden-404.php
+++ b/woostarter/patterns/hidden-404.php
@@ -3,28 +3,27 @@
  * Title: 404
  * Slug: woostarter/hidden-404
  * Inserter: no
+ * 
  */
-declare( strict_types = 1 );
 ?>
 
-<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
-<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:group {"metadata":{"name":"Page not found"},"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:spacer {"height":"var:preset|spacing|80"} -->
+<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"textAlign":"center","align":"wide"} -->
-<h2 class="wp-block-heading alignwide has-text-align-center" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a web page that is not found', 'woostarter' ); ?></h2>
+<!-- wp:heading {"textAlign":"center","level":1,"align":"wide"} -->
+<h1 class="wp-block-heading alignwide has-text-align-center" id="page-not-found"><?php echo esc_html_x( 'Page Not Found', 'Heading for a web page that is not found', 'woostarter' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center"><?php echo esc_html__( 'The page you are looking for does not exist.', 'woostarter' ); ?></p>
+<p class="has-text-align-center"><?php echo esc_html_x( 'The page you\'re looking for could not be found. Maybe try a search?', '404 error message', 't' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","buttonText":"Search","buttonUseIcon":true,"style":{"border":{"radius":"100px"},"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"borderColor":"theme-4"} /-->
 
-<!-- wp:search {"label":"Search","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search"} /-->
-
-<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
-<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|80"} -->
+<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
+</div>
+<!-- /wp:group -->

--- a/woostarter/patterns/product-related-3-column.php
+++ b/woostarter/patterns/product-related-3-column.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Title: Products, 3 column with Heading
+ * Slug: woostarter/product-related-3-column
+ * Categories: columns, featured
+ *
+ */
+?>
+
+<!-- wp:group {"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}}} -->
+<h2 class="wp-block-heading alignwide" style="padding-bottom:var(--wp--preset--spacing--40)"><?php esc_html_e( 'Browse products', 'woostarter' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:woocommerce/product-collection {"queryId":6,"query":{"perPage":3,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":true,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"dimensions":{"widthType":"fill","fixedWidth":"20px"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
+<div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"height":""} /-->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->

--- a/woostarter/templates/404.html
+++ b/woostarter/templates/404.html
@@ -2,7 +2,8 @@
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"layout":{"type":"constrained","contentSize":"400px","wideSize":"720px"}} -->
 <main class="wp-block-group">
-    <!-- wp:pattern {"slug":"woostarter/hidden-404"} /-->
+<!-- wp:pattern {"slug":"woostarter/hidden-404"} /-->
+<!-- wp:pattern {"slug":"woostarter/product-related-3-column"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Modify the 404 template to match the theme design.

- Updated 404.html file
- Updated `patterns/hidden-404.php`
- Added new `patterns/product-related-3-column.php`

Closes #54

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Pull down this branch on a new or existing store.
2. Go to `Appearance > Themes` and install the woostarter theme.
3. Go to `Appearance > Editor`.
4. Check if the **404 page template** is displayed correctly and looks like the screenshot below:
![404](https://github.com/user-attachments/assets/aa136e00-a445-4657-a213-f3b0df8855f8)

