### PR TITLE
Product Search template: updated template and patternized

### DIFF
--- a/woostarter/patterns/product-search-results.php
+++ b/woostarter/patterns/product-search-results.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Title: product-search-results
+ * Slug: woostarter/product-search-results
+ * Inserter: no
+ */
+?>
+
+<!-- wp:group {"tagName":"main","metadata":{"name":"Search Results"},"style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:spacer {"height":"var:preset|spacing|60"} -->
+<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
+<div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:query-title {"type":"search","level":2,"showPrefix":false,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"fontSize":"xx-large"} /-->
+
+<!-- wp:search {"showLabel":false,"placeholder":"<?php esc_html_e('Search products...', 'woostarter');?>","buttonText":"Search","query":{"post_type":"product"},"style":{"border":{"radius":"100px"}},"fontSize":"medium","borderColor":"theme-4"} /-->
+
+<!-- wp:woocommerce/product-collection-no-results {"align":"wide"} -->
+<!-- wp:paragraph -->
+<p>
+	<?php esc_html_e('No products were found matching your selection.', 'woostarter');?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- /wp:woocommerce/product-collection-no-results -->
+
+<!-- wp:woocommerce/store-notices /-->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"className":"alignwide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"fontSize":"large","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide has-large-font-size" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count /-->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p><?php esc_html_e('Sort by:', 'woostarter');?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/catalog-sorting {"fontSize":"large","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"auto"}}} /-->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|80"} -->
+<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->

--- a/woostarter/templates/product-search-results.html
+++ b/woostarter/templates/product-search-results.html
@@ -1,41 +1,7 @@
-<!-- wp:template-part {"slug":"header"} /-->
-
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
-<main class="wp-block-group">
-	<!-- wp:woocommerce/breadcrumbs /-->
-
-	<!-- wp:query-title {"type":"search","showPrefix":false,"align":"wide"} /-->
-
-	<!-- wp:woocommerce/store-notices /-->
-
-	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignwide">
-		<!-- wp:woocommerce/product-results-count /-->
-		<!-- wp:woocommerce/catalog-sorting /-->
-	</div>
-	<!-- /wp:group -->
-	<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","dimensions":{"widthType":"fill","fixedWidth":""},"displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"convertedFromProducts":false,"queryContextIncludes":["collection"],"align":"wide"} -->
-	<div class="wp-block-woocommerce-product-collection alignwide">
-		<!-- wp:woocommerce/product-template -->
-		<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
-		<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
-		<!-- wp:woocommerce/product-price {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
-		<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
-		<!-- /wp:woocommerce/product-template -->
-
-		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-		<!-- wp:query-pagination-previous /-->
-		<!-- wp:query-pagination-numbers /-->
-		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->
-
-		<!-- wp:woocommerce/product-collection-no-results {"align":"wide"} -->
-		<!-- wp:pattern {"slug":"woocommerce/no-products-found"} /-->
-		<!-- wp:pattern {"slug":"woocommerce/product-search-form"} /-->
-		<!-- /wp:woocommerce/product-collection-no-results -->
-	</div>
-	<!-- /wp:woocommerce/product-collection -->
-</main>
+<!-- wp:group {"metadata":{"name":"Sticky Header"},"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group"><!-- wp:template-part {"slug":"header"} /--></div>
 <!-- /wp:group -->
+
+<!-- wp:pattern {"slug":"woostarter/product-search-results"} /-->
 
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49 .

This PR updates the Product Search template and turns it into a pattern. I copied the contents of the demo site and added some changes to bring it closer to the figma design.

Editor | Frontend 
--- | ---
<img width="1674" alt="Screenshot 2025-04-11 at 12 06 50" src="https://github.com/user-attachments/assets/e1c27508-ce30-4a79-8901-1157e850130f" /> | <img width="1538" alt="Screenshot 2025-04-11 at 12 06 32" src="https://github.com/user-attachments/assets/e30f3ba2-045b-4b1c-9140-2936275381bf" />

To do:

- I don't know if we have a block for the Filters option that is shown on the design. That is missing
- The text for the number of results is not editable on the `product-results-count` block
- The `catalog-sorting` block select cannot be styled
- There is no option for "Load more" pagination on the block. I suppose this can be improved with the interactivity API in the future

I personally don't think any of those are blockers for a first version of the theme, but we should make note of them and add them to a tracking issue of "Good to haves" for the future