### PR TITLE
Styled select for sort order

### DIFF
--- a/purple/patterns/hidden-product-grid-with-filters.php
+++ b/purple/patterns/hidden-product-grid-with-filters.php
@@ -18,12 +18,12 @@
 <div class="wp-block-column" style="flex-basis:88%"><!-- wp:group {"className":"alignwide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p><?php esc_html_e('Sort by:', 'purple');?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:woocommerce/catalog-sorting {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+<!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>

--- a/purple/style.css
+++ b/purple/style.css
@@ -57,6 +57,151 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
     align-items: flex-start;
 }
 
+/* Catalog sort order select — CSS customizable select (base-select).
+ * Continues PR #82 exploration: https://github.com/woocommerce/woo-themes/pull/82
+ * Closed/open styles from Figma Dropdown/Default (1:6531) and Dropdown/Open Links (37:1153).
+ * Strip native chrome with appearance: none first; opt into base-select for the picker. */
+.woocommerce.wc-block-catalog-sorting {
+    font-size: var(--wp--preset--font-size--medium) !important;
+}
+
+.woocommerce.wc-block-catalog-sorting select.orderby {
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: var(--wp--preset--color--theme-1);
+    background-image: url('data:image/svg+xml;utf8,<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="%23111111"></path></svg>');
+    background-position: right center;
+    background-repeat: no-repeat;
+    background-size: 1.5em;
+    border: none;
+    border-radius: 0;
+    color: var(--wp--preset--color--theme-2);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--wp--preset--font-size--medium) !important;
+    font-weight: inherit;
+    line-height: 1.5625;
+    outline: none;
+    padding-block: 0;
+    padding-inline: 0 calc(1.5em + 10px);
+    vertical-align: middle;
+}
+
+@supports (appearance: base-select) {
+    .woocommerce.wc-block-catalog-sorting select.orderby,
+    .woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {
+        appearance: base-select;
+        background-color: var(--wp--preset--color--theme-1);
+        border: none;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby {
+        align-items: center;
+        background-image: none;
+        box-shadow: none;
+        display: inline-flex;
+        flex-direction: row;
+        gap: 10px;
+        outline: none;
+        padding: 0;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby:not(:open) > option {
+        display: none;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby:not(:open)::picker(select) {
+        display: none;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby .orderby-button {
+        appearance: none;
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+        color: inherit;
+        cursor: pointer;
+        display: inline;
+        font: inherit;
+        margin: 0;
+        order: 0;
+        outline: 0;
+        padding: 0;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby selectedcontent {
+        display: inline;
+        white-space: nowrap;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby::picker-icon {
+        background-image: url('data:image/svg+xml;utf8,<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg>');
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        block-size: 1.5em;
+        color: var(--wp--preset--color--theme-2);
+        content: '';
+        flex-shrink: 0;
+        inline-size: 1.5em;
+        order: 1;
+        transition: rotate 0.15s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby:open::picker-icon {
+        rotate: 180deg;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {
+        align-items: stretch;
+        background-color: var(--wp--preset--color--theme-1);
+        border-radius: 0;
+        box-sizing: border-box;
+        color: var(--wp--preset--color--theme-2);
+        display: flex;
+        flex-direction: column;
+        font-size: var(--wp--preset--font-size--medium);
+        gap: 0;
+        line-height: 1.5625;
+        margin-block-start: 12px;
+        min-width: anchor-size(width);
+        padding: 0;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby:open::picker(select) {
+        border: 1px solid var(--wp--preset--color--theme-6);
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby option::checkmark {
+        content: '';
+    }
+
+    /* Open list items — padding per option so hover fills a padded row. */
+    .woocommerce.wc-block-catalog-sorting select.orderby option {
+        background-color: transparent;
+        box-sizing: border-box;
+        color: var(--wp--preset--color--theme-2);
+        font-size: var(--wp--preset--font-size--medium);
+        gap: 0;
+        line-height: 1.5625;
+        min-block-size: auto;
+        padding: 12px 18px;
+        white-space: nowrap;
+        width: 100%;
+    }
+
+    .woocommerce.wc-block-catalog-sorting select.orderby option:enabled:hover,
+    .woocommerce.wc-block-catalog-sorting select.orderby option:focus {
+        background-color: var(--wp--preset--color--theme-5);
+        outline: none;
+    }
+
+    /* Underline the closed label while the menu is open (Dropdown/Click, 1875:53421). */
+    .woocommerce.wc-block-catalog-sorting select.orderby:open selectedcontent {
+        text-decoration: underline;
+    }
+}
+
 /* Navigation dropdown panel — desktop only.
  * Above the mobile overlay breakpoint, give the submenu its own
  * floating-panel styling (page-color background + soft shadow).

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -483,6 +483,11 @@
 					"text": "var(--wp--preset--color--theme-4)"
 				}
 			},
+			"woocommerce/catalog-sorting": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)"
+				}
+			},
 			"woocommerce/product-sale-badge": {
 				"typography": {
 					"fontSize":  "var(--wp--preset--font-size--small)",

--- a/purple/woocommerce/loop/orderby.php
+++ b/purple/woocommerce/loop/orderby.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Show options for ordering
+ *
+ * @see         https://woocommerce.com/document/template-structure/
+ * @package     WooCommerce\Templates
+ * @version     9.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$id_suffix = wp_unique_id();
+
+?>
+<form class="woocommerce-ordering" method="get">
+	<?php if ( $use_label ) : ?>
+		<label for="woocommerce-orderby-<?php echo esc_attr( $id_suffix ); ?>"><?php echo esc_html__( 'Sort by', 'woocommerce' ); ?></label>
+	<?php endif; ?>
+	<select
+		name="orderby"
+		class="orderby"
+		<?php if ( $use_label ) : ?>
+			id="woocommerce-orderby-<?php echo esc_attr( $id_suffix ); ?>"
+		<?php else : ?>
+			aria-label="<?php esc_attr_e( 'Shop order', 'woocommerce' ); ?>"
+		<?php endif; ?>
+	>
+		<button type="button" class="orderby-button">
+			<selectedcontent></selectedcontent>
+		</button>
+		<?php foreach ( $catalog_orderby_options as $id => $name ) : ?>
+			<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $orderby, $id ); ?>><?php echo esc_html( $name ); ?></option>
+		<?php endforeach; ?>
+	</select>
+	<input type="hidden" name="paged" value="1" />
+	<?php wc_query_string_form_fields( null, array( 'orderby', 'submit', 'paged', 'product-page' ) ); ?>
+</form>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is an experimental PR to try and implement https://developer.chrome.com/blog/a-customizable-select

This only applies to browsers that support this, and leaves other browsers to do their default thing. I think this would be better suited to do directly on the block, but I wanted to do the exploration regardless in the theme, to see how we like it. By adding the CSS to the theme.json file we also keep the door open for end users to remove it (if they know to find it!) should they wish so.

CHROME:

Before | After
--- | ---
<img width="846" alt="Screenshot 2025-04-25 at 11 04 00" src="https://github.com/user-attachments/assets/2757a31a-d7e3-4917-84b4-e2ecdc18ff3d" /> | <img width="582" alt="Screenshot 2025-04-25 at 11 02 41" src="https://github.com/user-attachments/assets/f15146ac-fb0f-4504-aa94-1427e55d602c" />


FIREFOX: 

Doesn't support it so it's unaffected

<img width="446" alt="Screenshot 2025-04-25 at 11 02 53" src="https://github.com/user-attachments/assets/d27ac2ea-78d9-41c7-9623-8f4bddcf7894" />