### PR TITLE
add page cart template

### DIFF
--- a/woostarter/patterns/page-cart.php
+++ b/woostarter/patterns/page-cart.php
@@ -9,6 +9,8 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group"><!-- wp:woocommerce/store-notices /-->
 
+<!-- wp:group {"align":"wide","layout":{"type":"constrained","wideSize":"66rem"}} -->
+<div class="wp-block-group alignwide">
 <!-- wp:woocommerce/cart -->
 <div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block -->
 <div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
@@ -129,6 +131,7 @@
 
 <!-- wp:woocommerce/product-new {"columns":4,"rows":1} /--></div>
 <!-- /wp:woocommerce/empty-cart-block --></div>
-<!-- /wp:woocommerce/cart --></main>
+<!-- /wp:woocommerce/cart --></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->
 <!-- /wp:woocommerce/page-content-wrapper -->

--- a/woostarter/patterns/page-cart.php
+++ b/woostarter/patterns/page-cart.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Title: page-cart
+ * Slug: woostarter/page-cart
+ * Inserter: no
+ */
+?>
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:woocommerce/store-notices /-->
+
+<!-- wp:woocommerce/cart -->
+<div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block -->
+<div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
+<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+<div class="wp-block-woocommerce-cart-line-items-block"></div>
+<!-- /wp:woocommerce/cart-line-items-block -->
+
+</div>
+<!-- /wp:woocommerce/cart-items-block -->
+
+<!-- wp:woocommerce/cart-totals-block -->
+<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
+<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
+<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-heading-block -->
+
+<!-- wp:woocommerce/cart-order-summary-coupon-form-block -->
+<div class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-coupon-form-block -->
+
+<!-- wp:woocommerce/cart-order-summary-totals-block -->
+<div class="wp-block-woocommerce-cart-order-summary-totals-block"><!-- wp:woocommerce/cart-order-summary-subtotal-block -->
+<div class="wp-block-woocommerce-cart-order-summary-subtotal-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-subtotal-block -->
+
+<!-- wp:woocommerce/cart-order-summary-fee-block -->
+<div class="wp-block-woocommerce-cart-order-summary-fee-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-fee-block -->
+
+<!-- wp:woocommerce/cart-order-summary-discount-block -->
+<div class="wp-block-woocommerce-cart-order-summary-discount-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-discount-block -->
+
+<!-- wp:woocommerce/cart-order-summary-shipping-block -->
+<div class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-shipping-block -->
+
+<!-- wp:woocommerce/cart-order-summary-taxes-block -->
+<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
+<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
+<!-- /wp:woocommerce/cart-order-summary-totals-block --></div>
+<!-- /wp:woocommerce/cart-order-summary-block -->
+
+<!-- wp:woocommerce/cart-express-payment-block -->
+<div class="wp-block-woocommerce-cart-express-payment-block"></div>
+<!-- /wp:woocommerce/cart-express-payment-block -->
+
+<!-- wp:woocommerce/proceed-to-checkout-block -->
+<div class="wp-block-woocommerce-proceed-to-checkout-block"></div>
+<!-- /wp:woocommerce/proceed-to-checkout-block -->
+
+<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
+<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
+<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
+<!-- /wp:woocommerce/cart-totals-block -->
+
+<!-- wp:woocommerce/cart-cross-sells-block -->
+<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
+<h2 class="wp-block-heading has-large-font-size"><?php esc_html_e('Browse products', 'woostarter');?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:woocommerce/cart-cross-sells-products-block -->
+<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
+<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
+<!-- /wp:woocommerce/cart-cross-sells-block -->
+
+</div>
+<!-- /wp:woocommerce/filled-cart-block -->
+
+<!-- wp:woocommerce/empty-cart-block -->
+<div class="wp-block-woocommerce-empty-cart-block"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center"><?php esc_html_e('Your cart is empty', 'woostarter');?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop"><?php esc_html_e('Go to our shop', 'woostarter');?></a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php esc_html_e('Have an account? Log in&nbsp;to check out faster.', 'woostarter');?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Product Collection 5 Columns","categories":["woo-commerce","featured-selling"],"patternName":"woocommerce-blocks/product-collection-5-columns"},"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:spacer {"height":"calc( 0.25 * var(\u002d\u002dwp\u002d\u002dstyle\u002d\u002droot\u002d\u002dpadding-right, var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dgap\u002d\u002dhorizontal)))"} -->
+<div style="height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"level":3,"align":"wide"} -->
+<h3 class="wp-block-heading alignwide"><?php esc_html_e('Browse products', 'woostarter');?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"featured":true},"tagName":"div","displayLayout":{"type":"flex","columns":4},"dimensions":{"widthType":"fill","fixedWidth":""},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
+<div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true,"aspectRatio":"3/5"} /-->
+
+<!-- wp:post-title {"textAlign":"left","isLink":true,"style":{"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"small"} /-->
+<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:spacer {"height":"calc( 0.25 * var(\u002d\u002dwp\u002d\u002dstyle\u002d\u002droot\u002d\u002dpadding-right, var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dgap\u002d\u002dhorizontal)))"} -->
+<div style="height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+
+<!-- wp:woocommerce/product-new {"columns":4,"rows":1} /--></div>
+<!-- /wp:woocommerce/empty-cart-block --></div>
+<!-- /wp:woocommerce/cart --></main>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->

--- a/woostarter/patterns/page-cart.php
+++ b/woostarter/patterns/page-cart.php
@@ -128,8 +128,7 @@
 <div style="height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
-
-<!-- wp:woocommerce/product-new {"columns":4,"rows":1} /--></div>
+</div>
 <!-- /wp:woocommerce/empty-cart-block --></div>
 <!-- /wp:woocommerce/cart --></div>
 <!-- /wp:group --></main>

--- a/woostarter/patterns/woocommerce-page-cart.php
+++ b/woostarter/patterns/woocommerce-page-cart.php
@@ -1,24 +1,23 @@
 <?php
 /**
- * Title: page-cart
- * Slug: woostarter/page-cart
- * Inserter: no
+ * Title: WooCommerce Page Cart
+ * Slug: woostarter/woocommerce-page-cart
+ * Categories: page
+ * Post Types: page, wp_template
+ * Viewport width: 1400
  */
 ?>
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group"><!-- wp:woocommerce/store-notices /-->
 
-<!-- wp:group {"align":"wide","layout":{"type":"constrained","wideSize":"66rem"}} -->
-<div class="wp-block-group alignwide">
-<!-- wp:woocommerce/cart -->
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:woocommerce/cart -->
 <div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block -->
 <div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
 <div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
 <div class="wp-block-woocommerce-cart-line-items-block"></div>
-<!-- /wp:woocommerce/cart-line-items-block -->
-
-</div>
+<!-- /wp:woocommerce/cart-line-items-block --></div>
 <!-- /wp:woocommerce/cart-items-block -->
 
 <!-- wp:woocommerce/cart-totals-block -->
@@ -75,20 +74,22 @@
 <!-- wp:woocommerce/cart-cross-sells-products-block -->
 <div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
 <!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
-<!-- /wp:woocommerce/cart-cross-sells-block -->
-
-</div>
+<!-- /wp:woocommerce/cart-cross-sells-block --></div>
 <!-- /wp:woocommerce/filled-cart-block -->
 
 <!-- wp:woocommerce/empty-cart-block -->
 <div class="wp-block-woocommerce-empty-cart-block"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center"><?php esc_html_e('Your cart is empty', 'woostarter');?></h2>
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<h2 class="wp-block-heading has-text-align-center" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e('Your shopping bag is empty', 'woostarter');?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop"><?php esc_html_e('Go to our shop', 'woostarter');?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop"><?php esc_html_e('Return to shop', 'woostarter');?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 
@@ -96,39 +97,33 @@
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center"><?php esc_html_e('Have an account? Log in&nbsp;to check out faster.', 'woostarter');?></p>
+<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} -->
+<p class="has-text-align-center has-theme-4-color has-text-color has-link-color has-small-font-size"><?php /* Translators: 1. is the start of a 'a' HTML element, 2. is the end of a 'a' HTML element */ 
+echo sprintf( esc_html__( 'Have an account? %1$sLog in%2$s to check out faster.', 'woostarter' ), '<a href="' . esc_url( '/my-account' ) . '">', '</a>' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"metadata":{"name":"Product Collection 5 Columns","categories":["woo-commerce","featured-selling"],"patternName":"woocommerce-blocks/product-collection-5-columns"},"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:spacer {"height":"calc( 0.25 * var(\u002d\u002dwp\u002d\u002dstyle\u002d\u002droot\u002d\u002dpadding-right, var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dgap\u002d\u002dhorizontal)))"} -->
-<div style="height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:heading {"level":3,"align":"wide"} -->
-<h3 class="wp-block-heading alignwide"><?php esc_html_e('Browse products', 'woostarter');?></h3>
+<!-- wp:group {"metadata":{"name":"Product Collection 5 Columns","categories":["woo-commerce","featured-selling"],"patternName":"woocommerce-blocks/product-collection-5-columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3,"align":"wide"} -->
+<h3 class="wp-block-heading alignwide has-text-align-center"><?php esc_html_e('You might like', 'woostarter');?></h3>
 <!-- /wp:heading -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"featured":true},"tagName":"div","displayLayout":{"type":"flex","columns":4},"dimensions":{"widthType":"fill","fixedWidth":""},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
+<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"featured":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill","fixedWidth":""},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
-<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true,"aspectRatio":"3/5"} /-->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"aspectRatio":"3/5"} -->
+<!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20","top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} /-->
+<!-- /wp:woocommerce/product-image -->
 
 <!-- wp:post-title {"textAlign":"left","isLink":true,"style":{"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
 <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"small"} /-->
 <!-- /wp:woocommerce/product-template --></div>
-<!-- /wp:woocommerce/product-collection -->
-
-<!-- wp:spacer {"height":"calc( 0.25 * var(\u002d\u002dwp\u002d\u002dstyle\u002d\u002droot\u002d\u002dpadding-right, var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dgap\u002d\u002dhorizontal)))"} -->
-<div style="height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
-<!-- /wp:group -->
-</div>
+<!-- /wp:woocommerce/product-collection --></div>
+<!-- /wp:group --></div>
 <!-- /wp:woocommerce/empty-cart-block --></div>
 <!-- /wp:woocommerce/cart --></div>
 <!-- /wp:group --></main>

--- a/woostarter/templates/page-cart.html
+++ b/woostarter/templates/page-cart.html
@@ -1,5 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
  
-<!-- wp:pattern {"slug":"woostarter/page-cart"} /-->
+<!-- wp:pattern {"slug":"woostarter/woocommerce-page-cart"} /-->
  
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/woostarter/templates/page-cart.html
+++ b/woostarter/templates/page-cart.html
@@ -1,11 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-group">
-	<!-- wp:woocommerce/store-notices /-->
-	<!-- wp:post-title {"align":"wide","level":1} /-->
-	<!-- wp:post-content {"align":"wide"} /-->
-</main>
-<!-- /wp:group -->
-<!-- /wp:woocommerce/page-content-wrapper -->
+ 
+<!-- wp:pattern {"slug":"woostarter/page-cart"} /-->
+ 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/woostarter/theme.json
+++ b/woostarter/theme.json
@@ -349,6 +349,24 @@
 					  "bottom": "var(--wp--preset--spacing--30)"
 					}
 				}
+			},
+			"woocommerce/product-sale-badge": {
+				"typography": {
+					"fontSize":  "var(--wp--preset--font-size--small)",
+					"lineHeight": "1.7",
+					"fontWeight": "400",
+					"textTransform": "none"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--theme-7)",
+					"text": "var(--wp--preset--color--theme-1)"
+				},
+				"border": {
+					"radius": "0",
+					"style": "solid",
+					"width": "1px",
+					"color": "var(--wp--preset--color--theme-7)"
+				}
 			}
 		},
 		"color": {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


The block needs a lot of work to allow full customization but it has solid defaults for a possible v1. Attempting to implement the figma design (Gum9XNWccPKfkVRFk1Whsp-fi-4552_47031) I found:

- It's impossible to deal with the locked blocks using the editor UI, but I was able to change the template directly in the code. This is not ideal and there's nothing like this in core, so it will confuse future themers/extenders https://github.com/woocommerce/woocommerce/issues/42365
- The cross sells block is not customizable at all and we can't style or remove any of the internal elements of it. It should be using the product collection (I asked @senadir about this). Changing the number of columns to over 3 doesn't work as expected and the 4th item will wrap no matter what. The heading inside the Cart cross sells wrapper can't change alignment, when you do, nothing happens. https://github.com/woocommerce/woocommerce/issues/58612
- The cart inner blocks are dealing with the layout, when that should be done by layout core blocks such as group or columns. The css is too opinionated. If I try to insert a block inside filled-cart-block and before cart-items-block the layout is completely broken. 

I will proceed to report all of that in the woocommerce repo, and as those issues get fixed we can revisit this template/pattern in the future

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes WOOTHME-90

<!-- Begin testing instructions -->

Empty Cart

<img width="1690" alt="Screenshot 2025-06-06 at 13 44 07" src="https://github.com/user-attachments/assets/269be03c-917a-4953-8dfc-504372e76342" />

Filled Cart

<img width="1644" alt="Screenshot 2025-06-06 at 13 43 55" src="https://github.com/user-attachments/assets/cfd5cdc2-9c61-4694-a5a7-92bf07c36c34" />