### PR TITLE
added main tag to coming soon page

### DIFF
--- a/woostarter/templates/coming-soon.html
+++ b/woostarter/templates/coming-soon.html
@@ -1,1 +1,7 @@
-<!-- wp:pattern {"slug":"woostarter/coming-soon"} /-->
+<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:0">
+	
+	<!-- wp:pattern {"slug":"woostarter/coming-soon"} /-->
+
+</main>
+<!-- /wp:group -->


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially addresses DSGWOO-555

We need a main tag on every template, this was the only one missing according to the theme check plugin

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To check the coming soon page:

1. With WooCommerce installed navigate to Woocommerce > Settings > Site visibility
2. Enable the coming soon page
3. Navigate to /shop to see the pattern


<!-- End testing instructions -->
