### PR TITLE
Fix single post template widths controls

### DIFF
--- a/woostarter/templates/single.html
+++ b/woostarter/templates/single.html
@@ -34,7 +34,7 @@
 	<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 	
-	<!-- wp:post-content {"lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} /-->
+	<!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"full","layout":{"type":"constrained"}} /-->
 	
 	<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
 	<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Not only weren't the full and wide widths not working, we also had block validation errors. This PR fixes both issues.

Closes #127 .

<!-- Begin testing instructions -->

Now it looks like this:

Site editor:

<img width="1925" alt="Screenshot 2025-06-26 at 10 20 07" src="https://github.com/user-attachments/assets/3ba2d871-8269-4b6f-b7f4-f5cb695d7a20" />


Frontend:

<img width="1870" alt="Screenshot 2025-06-26 at 10 20 30" src="https://github.com/user-attachments/assets/be057039-4a39-46ab-934b-b3fb0af26ce9" />

