### PR TITLE
Fix: Remove duplicated "My Account" and reposition as icon-only in header

### DIFF
--- a/woostarter/parts/header-alternative.html
+++ b/woostarter/parts/header-alternative.html
@@ -6,7 +6,7 @@
 <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"align":"wide"} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center is-not-stacked-on-mobile"><!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%"><!-- wp:navigation /--></div>
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%"><!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"30%"} -->

--- a/woostarter/parts/header.html
+++ b/woostarter/parts/header.html
@@ -10,7 +10,7 @@
         <div class="wp-block-group">
             <!-- wp:site-title {"textAlign":"center"} /-->
 
-            <!-- wp:navigation {"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
+            <!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
         </div>
         <!-- /wp:group -->
 

--- a/woostarter/parts/header.html
+++ b/woostarter/parts/header.html
@@ -1,23 +1,31 @@
 <!-- wp:group {"metadata":{"name":"Default header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:site-title {"textAlign":"center"} /-->
-
-<!-- wp:navigation {"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"wrap"}} /--><!-- wp:woocommerce/customer-account {"displayStyle":"text_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /--></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 <div class="wp-block-group">
-<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
-<!-- wp:woocommerce/mini-cart /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
+    <!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+    <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+    <!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+    <div class="wp-block-group alignwide">
+        <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+        <div class="wp-block-group">
+            <!-- wp:site-title {"textAlign":"center"} /-->
+
+            <!-- wp:navigation {"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
+        </div>
+        <!-- /wp:group -->
+
+        <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+        <div class="wp-block-group">
+            <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+            <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
+            <!-- wp:woocommerce/mini-cart /-->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+
+    <!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+    <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+</div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes an issue where the "My Account" element was duplicated in the header layout. Previously, it appeared both inside and outside the navigation row.

- Fixed the code format of the header for readability.

Closes #141 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to the theme editor and open header pattern.
2. Check header patten has `My Account` icon as shown in the screenshot below.

<img width="1462" alt="Screenshot at Jul 03 00-53-03" src="https://github.com/user-attachments/assets/77cedc40-5d11-4b04-acbb-3d98a21da900" />

