### PR TITLE
changed text and explicit colors

### DIFF
--- a/woostarter/patterns/footer.php
+++ b/woostarter/patterns/footer.php
@@ -14,7 +14,7 @@
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"40%"} -->
 <div class="wp-block-column" style="flex-basis:40%"><!-- wp:site-title {"level":0} /-->
 
-<!-- wp:site-tagline {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4"} /-->
+<!-- wp:site-tagline /-->
 
 <!-- wp:spacer {"height":"var:preset|spacing|30"} -->
 <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
@@ -92,12 +92,12 @@
 <!-- /wp:spacer -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"align":"left","style":{"typography":{"textTransform":"uppercase"},"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} -->
-<p class="has-text-align-left has-theme-4-color has-text-color has-link-color has-small-font-size" style="text-transform:uppercase"><?php esc_html_e('© 2025 Elke', 'woostarter');?></p>
+<div class="wp-block-group alignfull" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"align":"left","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+<p class="has-text-align-left has-small-font-size" style="text-transform:uppercase"><?php esc_html_e('© 2025', 'woostarter');?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"left","style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} -->
-<p class="has-text-align-left has-theme-4-color has-text-color has-link-color has-small-font-size"><?php esc_html_e('Designed with WordPress', 'woostarter');?></p>
+<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
+<p class="has-text-align-left has-small-font-size"><?php esc_html_e('Designed with WordPress', 'woostarter');?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 

--- a/woostarter/styles/block/section-1.json
+++ b/woostarter/styles/block/section-1.json
@@ -18,6 +18,11 @@
                 "color": {
                     "text": "color-mix(in srgb, currentColor 25%, transparent)"
                 }
+            },
+            "core/site-tagline": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
             }
         },
         "elements": {

--- a/woostarter/styles/block/section-2.json
+++ b/woostarter/styles/block/section-2.json
@@ -18,6 +18,11 @@
                 "color": {
                     "text": "color-mix(in srgb, currentColor 25%, transparent)"
                 }
+            },
+            "core/site-tagline": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
             }
         },
         "elements": {

--- a/woostarter/styles/block/section-3.json
+++ b/woostarter/styles/block/section-3.json
@@ -18,6 +18,11 @@
                 "color": {
                     "text": "color-mix(in srgb, currentColor 25%, transparent)"
                 }
+            },
+            "core/site-tagline": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
             }
         },
         "elements": {

--- a/woostarter/theme.json
+++ b/woostarter/theme.json
@@ -354,6 +354,11 @@
 					"text": "var(--wp--preset--color--theme-6)"
 				}
 			},
+			"core/site-tagline": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-4)"
+				}
+			},
 			"core/site-title": {
 				"elements": {
 					"link": {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes WOOTHME-141

This changes the ext of the copyright but also removes hardcoded colors from the pattern. I can't remove it from the social links sadly because that can't be styled via theme.json yet

<img width="1664" alt="Screenshot 2025-07-07 at 16 48 10" src="https://github.com/user-attachments/assets/74de7873-2501-4f51-b12c-22c603eac45d" />
<img width="1688" alt="Screenshot 2025-07-07 at 16 46 47" src="https://github.com/user-attachments/assets/3afe0cf7-8fa2-4a5a-9a73-1d577d2dee82" />

