### PR TITLE
Fix: Consistent Header Spacing and Allow Optional Cart Icon on Checko…

### DIFF
--- a/purple/parts/checkout-header.html
+++ b/purple/parts/checkout-header.html
@@ -1,9 +1,26 @@
-<!-- wp:group {"area":"header","metadata":{"name":"Checkout Header"},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"area":"header","metadata":{"name":"Checkout Header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|20","top":"var:preset|spacing|20"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
-			<!-- wp:site-title {"level":0} /-->
-		</div>
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group">
+				<!-- wp:site-title {"level":0} /-->
+			</div>
+		<!-- /wp:group -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+			<div class="wp-block-group">
+				<!-- wp:woocommerce/mini-cart /-->
+			</div>
+		<!-- /wp:group -->
+	</div>
 	<!-- /wp:group -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses two UI issues on the checkout page:

- Fixes inconsistent spacing between the checkout page header and the headers on other pages to match the design more closely and maintain visual consistency.
- Allows optional display of the cart icon on the checkout page header via CSS customization, while maintaining the default behavior of hiding it to reduce customer distraction (as discussed in [woocommerce/woocommerce-blocks#7760](https://github.com/woocommerce/woocommerce-blocks/issues/7760)).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #162 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

How to test this PR:

1. Go to the Cart page and observe the header layout.
2. Go to the Checkout page and verify:
- Header spacing is now visually consistent with other pages.
- Cart icon remains hidden by default.
3. Apply custom CSS (example provided below) to show the cart icon on the checkout page:
```
.woocommerce-checkout .wp-block-woocommerce-mini-cart  {
    visibility: visible !important;
}
```

<!-- End testing instructions -->
