### PR TITLE
Fix site title underline on hover

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -356,11 +356,6 @@
 					"link": {
 						"typography": {
 							"textDecoration": "none"
-						},
-						":hover": {
-							"typography": {
-								"textDecoration": "underline"
-							}
 						}
 					}
 				},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the `:hover` `textDecoration: underline` rule from the `core/site-title` element in `theme.json`. The link element already declares `textDecoration: none` as its default state, so the hover override was the only thing causing the underline. Dropping it leaves hover matching default — no underline, no flicker.

Linear: [WOOPRD-1518](https://linear.app/a8c/issue/WOOPRD-1518/site-title-underline-on-hover)

### How to test the changes in this Pull Request:

1. Activate the Purple theme on a test site (or pull this branch into the demo at https://purple.mystagingwebsite.com/).
2. Load any page that displays the header (e.g., the homepage).
3. Hover over the site title in the header.
4. Confirm no underline appears on hover. The site title should remain undecorated in both default and hover states.
5. As a regression check, hover the primary nav links — they should still show their hover state (color shift), confirming the change is scoped to the site title only.