### PR TITLE
Fix single product quantity stepper height

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -37,3 +37,13 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
     padding-top: var(--wp--preset--spacing--60);
     padding-bottom: var(--wp--preset--spacing--70);
 }
+
+/* Align the quantity stepper height with the Add to Cart button.
+ * Approximates the button's intrinsic height: padding (0.75em top + 0.75em bottom)
+ * + line-height + 2px border. */
+.wp-block-woocommerce-add-to-cart-with-options-quantity-selector,
+.wc-block-components-quantity-selector {
+    min-height: calc(0.75em * 2 + 1.5em + 2px);
+    display: flex;
+    align-items: stretch;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The default WooCommerce quantity stepper renders shorter than the Add to Cart button, so when they appear side by side on the single product page (via `wp:woocommerce/add-to-cart-with-options`) the two visually misalign.

This PR adds a `min-height` to the stepper container in `style.css` that matches the button's intrinsic height (`padding + line-height + 2px border`), plus `display: flex` / `align-items: stretch` so the stepper's input and increment controls fill the new height cleanly.

Targets both class variants WooCommerce may render:
- `.wp-block-woocommerce-add-to-cart-with-options-quantity-selector`
- `.wc-block-components-quantity-selector`

Linear: [WOOPRD-1515](https://linear.app/a8c/issue/WOOPRD-1515/single-product-page-adjust-counter-height)

### Screenshots

Confirmed working on mobile and desktop layouts — screenshots to be attached in PR body / comment.

### How to test the changes in this Pull Request:

1. Activate the Purple theme on a test site (or pull this branch into the demo at https://purple.mystagingwebsite.com/).
2. Navigate to any single product page.
3. Confirm the quantity stepper (− / count / +) and the Add to Cart button are the same height, with the controls in the stepper visually centered.
4. Test at both mobile and desktop widths.
5. Regression check: the stepper input + increment buttons should still be clickable and functional — increment, decrement, and direct entry all work.
<img width="782" height="1140" alt="CleanShot 2026-05-12 at 14 02 38@2x" src="https://github.com/user-attachments/assets/ab6d1e8b-a1f7-4d01-8531-f42d959907ca" />
<img width="782" height="1140" alt="CleanShot 2026-05-12 at 14 02 38@2x" src="https://github.com/user-attachments/assets/ab6d1e8b-a1f7-4d01-8531-f42d959907ca" />
 