### PR TITLE
Fix reviews form cookies-consent checkbox alignment

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -50,3 +50,9 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 .woocommerce-account .addresses address {
     font-style: normal;
 }
+
+/* Checkbox alignment for reviews form */
+
+.wp-block-woocommerce-product-review-form .comment-form-cookies-consent {
+    align-items: flex-start;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the single product page, the \"Save my name, email, and website…\" cookies-consent checkbox in the reviews form was visually misaligned with its label — the label appeared higher than the checkbox.

The cause: WooCommerce's `product-review-form` block ships its own CSS that forces `display: flex` on the cookies-consent paragraph but doesn't set an `align-items` value. The result is the checkbox and the label sit at different heights along the cross-axis.

This PR adds `align-items: flex-start` to the same selector so the checkbox and the first line of the label share a top edge. Top-alignment (rather than center) is intentional — the label is long enough to wrap on narrow viewports, and top-aligned reads more naturally than center when text spans multiple lines.

Linear: [WOOPRD-1549](https://linear.app/a8c/issue/WOOPRD-1549/reviews-checkbox)

### How to test the changes in this Pull Request:

1. Pull this branch and activate the Purple theme on a test site, or visit the demo at https://purple.mystagingwebsite.com/ once deployed.
2. Open any single product page.
3. **Log out** (the cookies-consent checkbox only renders for guests).
4. Scroll to the Reviews section and click \"Be the first to review\" / \"Add a review\" to expose the form.
5. Confirm the cookies-consent checkbox and the start of its label sit on the same top edge.
6. Resize the browser to narrow widths so the label wraps to multiple lines — confirm the checkbox stays aligned with the first line.

Before:

<img width="770" height="284" alt="CleanShot 2026-06-03 at 16 05 12@2x" src="https://github.com/user-attachments/assets/98b0ec38-2a9e-4be6-afff-9bd27d925936" />
<img width="1168" height="260" alt="CleanShot 2026-06-03 at 16 05 21@2x" src="https://github.com/user-attachments/assets/36838564-4848-49a0-abc1-63a41ad0a879" />

After:
<img width="1412" height="258" alt="CleanShot 2026-06-03 at 15 58 04@2x" src="https://github.com/user-attachments/assets/39b3b596-db01-44b0-a299-b16b67537bc3" />
<img width="774" height="472" alt="CleanShot 2026-06-03 at 15 58 16@2x" src="https://github.com/user-attachments/assets/3ecf1d76-ab60-43c7-bb25-98fa90bcf9f5" />
