### PR TITLE
Style navigation dropdown panel

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -56,3 +56,23 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 .wp-block-woocommerce-product-review-form .comment-form-cookies-consent {
     align-items: flex-start;
 }
+
+/* Navigation dropdown panel — desktop only.
+ * Above the mobile overlay breakpoint, give the submenu its own
+ * floating-panel styling (page-color background + soft shadow).
+ * Below 600px the nav opens as a full overlay and WordPress's own
+ * styles already render flat submenus, so this rule stays out.
+ *
+ * !important is needed because WordPress core ships a hardcoded
+ * .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container
+ * rule at higher specificity than any theme.json output.
+ *
+ * This lives in style.css (rather than theme.json's css field)
+ * because that field strips @media queries during sanitization. */
+@media (min-width: 600px) {
+    .wp-block-navigation .wp-block-navigation__submenu-container {
+        background-color: var(--wp--preset--color--theme-1) !important;
+        border: none !important;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    }
+}

--- a/purple/style.css
+++ b/purple/style.css
@@ -70,7 +70,7 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
  * This lives in style.css (rather than theme.json's css field)
  * because that field strips @media queries during sanitization. */
 @media (min-width: 600px) {
-    .wp-block-navigation .wp-block-navigation__submenu-container {
+    .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
         background-color: var(--wp--preset--color--theme-1) !important;
         border: none !important;
         box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);

--- a/purple/style.css
+++ b/purple/style.css
@@ -63,16 +63,22 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
  * Below 600px the nav opens as a full overlay and WordPress's own
  * styles already render flat submenus, so this rule stays out.
  *
- * !important is needed because WordPress core ships a hardcoded
+ * The :root prefix lifts this above WordPress core's hardcoded
  * .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container
- * rule at higher specificity than any theme.json output.
+ * rule on specificity alone, so we win the cascade WITHOUT !important.
+ * That matters: a Navigation background color set in the editor is
+ * applied with !important (or inline), so an !important here would
+ * override the user's choice. Without it, the user's color wins and
+ * this rule only supplies the themed default. The :not(.has-background)
+ * guard mirrors core so we also stay out of the way when the user has
+ * set their own nav background.
  *
  * This lives in style.css (rather than theme.json's css field)
  * because that field strips @media queries during sanitization. */
 @media (min-width: 600px) {
-    .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
-        background-color: var(--wp--preset--color--theme-1) !important;
-        border: none !important;
+    :root .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
+        background-color: var(--wp--preset--color--theme-1);
+        border: none;
         box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
     }
 }

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -304,9 +304,6 @@
 					"blockGap": "var(--wp--preset--spacing--40)"
 				}
 			},
-			"core/navigation-submenu": {
-				"css": "& .wp-block-navigation__submenu-container{background-color:var(--wp--preset--color--theme-1)!important;border:none!important;box-shadow:0 4px 16px rgba(0,0,0,0.12);}"
-			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)" 

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -304,6 +304,9 @@
 					"blockGap": "var(--wp--preset--spacing--40)"
 				}
 			},
+			"core/navigation-submenu": {
+				"css": "& .wp-block-navigation__submenu-container{background-color:var(--wp--preset--color--theme-1)!important;border:none!important;box-shadow:0 4px 16px rgba(0,0,0,0.12);}"
+			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)" 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The navigation dropdown panel was using WordPress core's hardcoded fallback styling (`background-color: #fff`, `border: 1px solid #00000026`), which clashed with style variations whose page background isn't white — most visibly in **Powder** (sage gray background → bright white dropdown).

This PR adds a `core/navigation-submenu` block style in `theme.json` that:

- Sets the dropdown background to `var(--wp--preset--color--theme-1)` so it matches the active variation's page color (sage in Powder, white in Default/Petunia, cream in Parchment, etc.)
- Removes the default 1px border
- Adds a soft `box-shadow` (`0 4px 16px rgba(0,0,0,0.12)`) so the panel still reads as a floating element against any page background

### Why `!important`?

WordPress core's stylesheet ships:

```css
.wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
    background-color: #fff;
    border: 1px solid #00000026;
}
```

That selector has specificity `(0, 3, 1)`. Theme.json's `css` field compiles to `:root :where(...)` at `(0, 0, 1)` — `:where()` zeroes out its inner specificity by design. So core's rule wins the cascade in every variation, and a theme override needs `!important` to take effect. This is a known limitation when theming the navigation submenu.

Linear: [WOOPRD-1560](https://linear.app/a8c/issue/WOOPRD-1560/apply-background-color-to-dropdown-background)

### How to test the changes in this Pull Request:

1. Pull this branch and activate the Purple theme on a test site.
2. Set up a menu with at least one parent item that has children (a submenu).
3. Open the front end and hover the parent nav item to expose the dropdown.
4. **Powder variation**: dropdown background should be sage gray (#d6d8c7) matching the page, with a soft floating shadow.
5. Switch to other variations (Default, Petunia, Parchment, Poppy, Pale Pumpkin) and confirm the dropdown adopts each one's page background and stays visually defined via the shadow.

Before:
<img width="1180" height="398" alt="CleanShot 2026-06-04 at 13 20 53@2x" src="https://github.com/user-attachments/assets/3e8da150-3022-41b3-8373-641392007429" />


After:
Desktop inherits theme color
<img width="1018" height="340" alt="CleanShot 2026-06-03 at 17 08 32@2x" src="https://github.com/user-attachments/assets/cf085c90-c4b8-4f24-b336-a6cb0c759f21" />

Mobile stays white
<img width="786" height="896" alt="CleanShot 2026-06-04 at 13 14 57@2x" src="https://github.com/user-attachments/assets/166e74bb-ab4f-483c-aef6-9bc1645958e3" />
