### PR TITLE
Hide product results count on mobile (WOOPRD-1558)

### DIFF
--- a/purple/patterns/hidden-woocommerce-product-search-results.php
+++ b/purple/patterns/hidden-woocommerce-product-search-results.php
@@ -33,7 +33,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:group {"className":"alignwide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count /-->
+<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->

--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -19,7 +19,7 @@
 
 <!-- wp:column {"width":"88%"} -->
 <div class="wp-block-column" style="flex-basis:88%"><!-- wp:group {"className":"alignwide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count /-->
+<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->


### PR DESCRIPTION
## Summary
- Hide `woocommerce/product-results-count` on mobile in `product-grid-with-filters` and `hidden-woocommerce-product-search-results` using block visibility metadata
- Fixes broken shop page mobile toolbar layout when columns stack (WOOPRD-1558)

## Test plan
- [ ] Activate Purple theme on a test site (e.g. https://purple.mystagingwebsite.com/)
- [ ] Visit the shop page at mobile viewport (≤781px)
- [ ] Confirm "Showing all X results" is hidden on mobile
- [ ] Confirm sort controls and filter button still display correctly
- [ ] Confirm results count still shows on desktop/tablet
- [ ] Visit product search results and repeat mobile/desktop checks

Linear: [WOOPRD-1558](https://linear.app/a8c/issue/WOOPRD-1558/shop-page-mobile-filter-display-is-broken)

Made with [Cursor](https://cursor.com)