### PR TITLE
Improve checkout header spacing to match other pages (WOOPRD-3541)

### DIFF
--- a/purple/parts/checkout-header.html
+++ b/purple/parts/checkout-header.html
@@ -1,9 +1,14 @@
-<!-- wp:group {"area":"header","metadata":{"name":"Checkout Header"},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|20","top":"var:preset|spacing|20"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
-			<!-- wp:site-title {"level":0} /-->
-		</div>
+<!-- wp:group {"metadata":{"name":"Checkout Header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group alignwide" style="padding-top:8px;padding-bottom:8px"><!-- wp:site-title {"level":0,"style":{"typography":{"lineHeight":"1.23"}}} /--></div>
 	<!-- /wp:group -->
+	
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- Update `checkout-header` template part to match the default header's vertical spacing structure
- Add top and bottom `spacing|30` spacers and align inner group padding so checkout pages feel consistent with the rest of the site

## Test plan
- [ ] Activate Purple theme on a test site
- [ ] Visit the checkout page and compare header spacing to a standard page (e.g. shop or home)
- [ ] Confirm top/bottom spacing around the site title matches other pages
- [ ] Check mobile and desktop viewports
- [ ] Regression: confirm cart and other checkout flow pages still render correctly

Linear: [WOOPRD-3541](https://linear.app/a8c/issue/WOOPRD-3541/improve-checkout-header-spacing-to-match-other-pages)

Made with [Cursor](https://cursor.com)