### PR TITLE
Rebuild FAQ with core accordion block (WOOPRD-1555)

### DIFF
--- a/purple/patterns/faq-question-list.php
+++ b/purple/patterns/faq-question-list.php
@@ -7,16 +7,16 @@
  * Description: A list of questions and answers.
  */
 ?>
-<!-- wp:group {"metadata":{"name":"FAQ list of questions and answers"},"align":"full","layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"FAQ list of questions and answers","description":"A list of questions and answers.","categories":["text","about"]},"align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull"><!-- wp:spacer {"height":"var:preset|spacing|70"} -->
 <div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<!-- wp:heading {"className":"wp-block-heading","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"typography":{"textAlign":"center"}}} -->
 <h2 class="wp-block-heading has-text-align-center" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e('Frequently Asked Questions', 'purple');?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"align":"center"} -->
+<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"}}} -->
 <p class="has-text-align-center"><?php esc_html_e('All our garments are made of authentic 100% sheep’s wool.', 'purple');?></p>
 <!-- /wp:paragraph -->
 
@@ -24,69 +24,67 @@
 <div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:woocommerce/accordion-group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-woocommerce-accordion-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"icon":"chevron","style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
-<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span><?php esc_html_e('What’s the difference between cashmere and wool?', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h3>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div role="group" class="wp-block-accordion" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]}}} -->
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":3,"style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
+<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span class="wp-block-accordion-heading__toggle-title">What’s the difference between cashmere and wool?</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"isSelected":true,"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
 <p><?php esc_html_e('Wool is a natural fiber harvested from sheep. It’s known for its durability, breathability, and excellent insulation properties. Wool fibers are thicker and more robust than cashmere, making them ideal for outerwear, suits, and knitwear designed for long-term wear and colder climates. Cashmere is a natural fiber obtained from the undercoat of cashmere goats, primarily found in regions like Mongolia, Nepal, and northern China. Renowned for its exceptional softness, warmth, and lightweight feel, cashmere is significantly finer than sheep’s wool, which gives it a smooth, almost silky texture against the skin.', 'purple');?></p>
-<!-- /wp:paragraph --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"icon":"chevron","style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
-<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span><?php esc_html_e('How should I wash my knitwear?', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h3>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]}}} -->
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":3,"style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
+<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span class="wp-block-accordion-heading__toggle-title">How should I wash my knitwear?</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
 <p><?php esc_html_e('Wool is a natural fiber harvested from sheep. It’s known for its durability, breathability, and excellent insulation properties. Wool fibers are thicker and more robust than cashmere, making them ideal for outerwear, suits, and knitwear designed for long-term wear and colder climates. Cashmere is a natural fiber obtained from the undercoat of cashmere goats, primarily found in regions like Mongolia, Nepal, and northern China. Renowned for its exceptional softness, warmth, and lightweight feel, cashmere is significantly finer than sheep’s wool, which gives it a smooth, almost silky texture against the skin.', 'purple');?></p>
-<!-- /wp:paragraph --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"icon":"chevron","style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
-<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span><?php esc_html_e('Why does my knitwear pill and how can I prevent it?', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h3>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]}}} -->
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":3,"style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
+<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span class="wp-block-accordion-heading__toggle-title">Why does my knitwear pill and how can I prevent it?</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
 <p><?php esc_html_e('Wool is a natural fiber harvested from sheep. It’s known for its durability, breathability, and excellent insulation properties. Wool fibers are thicker and more robust than cashmere, making them ideal for outerwear, suits, and knitwear designed for long-term wear and colder climates. Cashmere is a natural fiber obtained from the undercoat of cashmere goats, primarily found in regions like Mongolia, Nepal, and northern China. Renowned for its exceptional softness, warmth, and lightweight feel, cashmere is significantly finer than sheep’s wool, which gives it a smooth, almost silky texture against the skin.', 'purple');?></p>
-<!-- /wp:paragraph --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"icon":"chevron","style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
-<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span><?php esc_html_e('What materials are best for sensitive skin?', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h3>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]}}} -->
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":3,"style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
+<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span class="wp-block-accordion-heading__toggle-title">What materials are best for sensitive skin?</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
 <p><?php esc_html_e('Wool is a natural fiber harvested from sheep. It’s known for its durability, breathability, and excellent insulation properties. Wool fibers are thicker and more robust than cashmere, making them ideal for outerwear, suits, and knitwear designed for long-term wear and colder climates. Cashmere is a natural fiber obtained from the undercoat of cashmere goats, primarily found in regions like Mongolia, Nepal, and northern China. Renowned for its exceptional softness, warmth, and lightweight feel, cashmere is significantly finer than sheep’s wool, which gives it a smooth, almost silky texture against the skin.', 'purple');?></p>
-<!-- /wp:paragraph --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"icon":"chevron","style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}}}} -->
-<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span><?php esc_html_e('How do I store knitwear during warmer months?', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h3>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]}}} -->
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":3,"style":{"spacing":{"padding":{"top":"0.88rem","bottom":"0.88rem"}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->
+<h3 class="wp-block-accordion-heading has-medium-font-size" style="font-style:normal;font-weight:400"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0.88rem;padding-bottom:0.88rem"><span class="wp-block-accordion-heading__toggle-title">How do I store knitwear during warmer months?</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
+<!-- wp:accordion-panel {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}}} -->
+<div role="region" class="wp-block-accordion-panel" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
 <p><?php esc_html_e('Wool is a natural fiber harvested from sheep. It’s known for its durability, breathability, and excellent insulation properties. Wool fibers are thicker and more robust than cashmere, making them ideal for outerwear, suits, and knitwear designed for long-term wear and colder climates. Cashmere is a natural fiber obtained from the undercoat of cashmere goats, primarily found in regions like Mongolia, Nepal, and northern China. Renowned for its exceptional softness, warmth, and lightweight feel, cashmere is significantly finer than sheep’s wool, which gives it a smooth, almost silky texture against the skin.', 'purple');?></p>
-<!-- /wp:paragraph --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
-
-</div>
-<!-- /wp:woocommerce/accordion-group -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item --></div>
+<!-- /wp:accordion -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|70"} -->
 <div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -201,6 +201,31 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/accordion-heading": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-2)"
+				},
+				"spacing": {
+					"padding": {
+						"top": "0",
+						"bottom": "0"
+					}
+				},
+				"typography": {
+					"fontSize":  "var(--wp--preset--font-size--medium)",
+					"fontWeight": "400"
+				}
+			},
+			"core/accordion-panel": {
+				"spacing": {
+					"margin": {
+						"top": "0"
+					},
+					"padding": {
+						"bottom": "var(--wp--preset--spacing--30)"
+					}
+				}
+			},
 			"core/button": {
 				"border": {
 					"radius": "0"
@@ -399,21 +424,6 @@
 				},
 				"spacing": {
 					"blockGap": "0"
-				}
-			},
-			"woocommerce/accordion-header": {
-				"color": {
-					"text": "var(--wp--preset--color--theme-2)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "0.75rem",
-						"bottom": "0.75rem"
-					}
-				},
-				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--medium)",
-					"fontWeight": "400"
 				}
 			},
 			"woocommerce/breadcrumbs": {


### PR DESCRIPTION
## Summary
- Rebuild `faq-question-list` using core accordion blocks (`accordion`, `accordion-item`, `accordion-heading`, `accordion-panel`) instead of WooCommerce accordion blocks
- Add `core/accordion-heading` and `core/accordion-panel` styles to `theme.json` for typography, spacing, and panel padding
- Remove `woocommerce/accordion-header` theme.json styles (no longer used by FAQ; product filters/details still use WooCommerce accordion)

## Test plan
- [ ] Activate Purple theme on a test site with WordPress 6.9+ (core accordion requires recent WP)
- [ ] Visit the About page (or any page using `page-about-additional-information`)
- [ ] Confirm FAQ accordion renders and expands/collapses correctly
- [ ] Confirm heading typography, item borders, and panel spacing match design
- [ ] Regression: verify product filter and single product accordions still look correct

Linear: [WOOPRD-1555](https://linear.app/a8c/issue/WOOPRD-1555/confirm-faq-is-it-built-with-core-accordion-69)

Made with [Cursor](https://cursor.com)