### PR TITLE
Use dynamic year in footer copyright (WOOPRD-3540)

### DIFF
--- a/purple/patterns/footer.php
+++ b/purple/patterns/footer.php
@@ -94,7 +94,12 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"align":"left","style":{"typography":{"textTransform":"uppercase"}}} -->
-<p class="has-text-align-left" style="text-transform:uppercase"><?php esc_html_e('© 2025', 'purple');?></p>
+<p class="has-text-align-left" style="text-transform:uppercase"><?php
+printf(
+	esc_html__( '© %s', 'purple' ),
+	esc_html( wp_date( 'Y' ) )
+);
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left"} -->


### PR DESCRIPTION
## Summary
- Replace hardcoded `© 2025` in the footer pattern with a dynamic year via `wp_date( 'Y' )`
- Keeps the string translatable with `printf()` and `esc_html__()`

## Test plan
- [ ] Activate Purple theme on a test site
- [ ] View any page and confirm the footer shows the current year (e.g. `© 2026`)
- [ ] Confirm uppercase styling and layout are unchanged

Linear: [WOOPRD-3540](https://linear.app/a8c/issue/WOOPRD-3540/footer-copyright-year-is-hardcoded-to-2025)

Made with [Cursor](https://cursor.com)