### PR TITLE
Improve My Account address styles (WOOPRD-1561)

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -37,3 +37,12 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
     padding-top: var(--wp--preset--spacing--60);
     padding-bottom: var(--wp--preset--spacing--70);
 }
+
+/* WOOPRD-1561: My Account address styles. */
+.woocommerce-account .addresses .title .edit {
+    float: none;
+}
+
+.woocommerce-account .addresses address {
+    font-style: normal;
+}


### PR DESCRIPTION
## Summary
- Left-align "Add/Edit address" links on the My Account addresses page by overriding WooCommerce's default `float: right`
- Remove browser default italic styling from `<address>` elements so empty-state copy reads consistently with the rest of the theme

## Test plan
- [ ] Activate Purple theme on a test site with WooCommerce
- [ ] Visit **My Account → Addresses** with no billing/shipping address set
- [ ] Confirm "Add Billing address" and "Add Shipping address" links are left-aligned
- [ ] Confirm "You have not set up this type of address yet." is not italic
- [ ] Add an address and confirm saved address text is also non-italic and layout still looks correct

Linear: [WOOPRD-1561](https://linear.app/a8c/issue/WOOPRD-1561/my-account-page-styles)

Made with [Cursor](https://cursor.com)