### PR TITLE
Update three-column categories pattern to use Featured Category block

### DIFF
--- a/purple/patterns/categories-on-three-columns.php
+++ b/purple/patterns/categories-on-three-columns.php
@@ -3,40 +3,40 @@
  * Title: Categories on three columns
  * Slug: purple/categories-on-three-columns
  * Categories: woo-commerce, purple
- * Keywords: text, media, columns	
- * Description: A section with three columns of categories with images.
+ * Keywords: text, media, columns
+ * Description: A section with three columns of Featured Category blocks.
  */
 ?>
 <!-- wp:group {"metadata":{"name":"Categories on three columns","patternName":"purple/categories-on-three-columns","description":"A section with three columns of categories with images.","categories":["text","media","columns"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/product-view3.webp","alt":"<?php esc_attr_e( 'Illustration of a folded shirt', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background  size-full" alt="<?php esc_attr_e( 'Illustration of a folded shirt', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/product-view3.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-column"><!-- wp:woocommerce/featured-category {"dimRatio":0,"imageFit":"cover","minHeight":600,"contentAlign":"center"} -->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Cardigans', 'woostarter');?></a></div>
+<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
-<!-- /wp:buttons --></div></div>
-<!-- /wp:cover --></div>
+<!-- /wp:buttons -->
+<!-- /wp:woocommerce/featured-category --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/product-view2.webp","alt":"<?php esc_attr_e( 'Illustration of a stack of folded shirts', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background  size-full" alt="<?php esc_attr_e( 'Illustration of a stack of folded shirts', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/product-view2.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-column"><!-- wp:woocommerce/featured-category {"dimRatio":0,"imageFit":"cover","minHeight":600,"contentAlign":"center"} -->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Sweaters', 'purple');?></a></div>
+<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
-<!-- /wp:buttons --></div></div>
-<!-- /wp:cover --></div>
+<!-- /wp:buttons -->
+<!-- /wp:woocommerce/featured-category --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/socks.webp","alt":"<?php esc_attr_e( 'An illustration of a pair of socks', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background  size-full" alt="<?php esc_attr_e( 'An illustration of a pair of socks', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/socks.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-column"><!-- wp:woocommerce/featured-category {"dimRatio":0,"imageFit":"cover","minHeight":600,"contentAlign":"center"} -->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Accessories', 'purple');?></a></div>
+<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
-<!-- /wp:buttons --></div></div>
-<!-- /wp:cover --></div>
+<!-- /wp:buttons -->
+<!-- /wp:woocommerce/featured-category --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Replaces the cover blocks in the "Categories on three columns" pattern (rendered on the single product page) with the WooCommerce **Featured Category** block, per [WOOPRD-1547](https://linear.app/a8c/issue/WOOPRD-1547).

### Changes
- **Categories left unset** — each block shows its category picker on insert, so merchants choose which categories to feature (no hardcoded term IDs, no PHP). Matches the approach merged for the two-column featured categories pattern (#201).
- Each block keeps a centered **"Shop now"** button (`is-style-button-1`), as in the original pattern.
- **Block settings only** — no custom CSS. No image overlay (the styled button carries its own contrast).

### ⚠️ Pending stakeholder confirmation
Per the discussion on the ticket, the Featured Category block has limitations vs the cover block it replaces:
- **No vertical content control** — the button stays vertically centered (can't be pinned to the bottom like the cover block did).
- **No aspect-ratio control** — a fixed `minHeight: 600` is used instead of the cover block's responsive `3/4` ratio.

Opening as a **draft** until stakeholders confirm they're happy to proceed with the block despite these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
