### PR TITLE
Clean up pattern headers: add keywords, lowercase categories

### DIFF
--- a/purple/patterns/footer.php
+++ b/purple/patterns/footer.php
@@ -3,6 +3,7 @@
  * Title: Footer
  * Slug: purple/footer
  * Categories: footer, purple
+ * Keywords: footer, contact, social, navigation, links
  * Block Types: core/template-part/footer
  * Description: A footer pattern with social links and navigation.
  */

--- a/purple/patterns/page-coming-soon.php
+++ b/purple/patterns/page-coming-soon.php
@@ -3,6 +3,7 @@
  * Title: Coming Soon
  * Slug: purple/coming-soon
  * Categories: purple
+ * Keywords: coming soon, starter, landing
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1400

--- a/purple/patterns/posts-three-columns-left-aligned.php
+++ b/purple/patterns/posts-three-columns-left-aligned.php
@@ -3,6 +3,7 @@
  * Title: List of posts with left aligned heading
  * Slug: purple/posts-three-columns-left-aligned
  * Categories: purple
+ * Keywords: posts, blog, query, columns, grid
  * Block Types: core/query
  */
 ?>

--- a/purple/patterns/posts-three-columns.php
+++ b/purple/patterns/posts-three-columns.php
@@ -3,6 +3,7 @@
  * Title: List of posts in three columns
  * Slug: purple/posts-three-columns
  * Categories: purple
+ * Keywords: posts, blog, query, columns, grid
  * Description: A list of posts, 3 columns, with featured image, post date and title.
  * Block Types: core/query
  */

--- a/purple/patterns/woocommerce-best-sellers-3-columns.php
+++ b/purple/patterns/woocommerce-best-sellers-3-columns.php
@@ -3,6 +3,7 @@
  * Title: Best Sellers Collection
  * Slug: purple/woocommerce-best-sellers-3-columns
  * Categories: woo-commerce, purple
+ * Keywords: woo-commerce, products, best sellers, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 3 column product grid.
  */

--- a/purple/patterns/woocommerce-best-sellers.php
+++ b/purple/patterns/woocommerce-best-sellers.php
@@ -3,6 +3,7 @@
  * Title: Best Sellers Collection
  * Slug: purple/woocommerce-best-sellers
  * Categories: purple
+ * Keywords: woo-commerce, products, best sellers, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
  */

--- a/purple/patterns/woocommerce-featured-products.php
+++ b/purple/patterns/woocommerce-featured-products.php
@@ -3,6 +3,7 @@
  * Title: Featured products
  * Slug: purple/woocommerce-featured-products
  * Categories: purple
+ * Keywords: woo-commerce, products, featured, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
  */

--- a/purple/patterns/woocommerce-new-arrivals.php
+++ b/purple/patterns/woocommerce-new-arrivals.php
@@ -3,6 +3,7 @@
  * Title: New Arrivals Collection
  * Slug: purple/woocommerce-new-arrivals
  * Categories: purple
+ * Keywords: woo-commerce, products, new arrivals, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
  */

--- a/purple/patterns/woocommerce-order-confirmation.php
+++ b/purple/patterns/woocommerce-order-confirmation.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Order Confirmation
  * Slug: purple/woocommerce-order-confirmation
  * Categories: page, purple
+ * Keywords: woo-commerce, order, confirmation, checkout, page
  * Post Types: page, wp_template
  * Viewport width: 1400
  * Description: A page template for the WooCommerce order confirmation page.

--- a/purple/patterns/woocommerce-page-cart.php
+++ b/purple/patterns/woocommerce-page-cart.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Page Cart
  * Slug: purple/woocommerce-page-cart
  * Categories: page, purple
+ * Keywords: woo-commerce, cart, shopping cart, page
  * Post Types: page, wp_template
  * Viewport width: 1400
  * Description: A page template for the WooCommerce cart page.

--- a/purple/patterns/woocommerce-product-related-4-column.php
+++ b/purple/patterns/woocommerce-product-related-4-column.php
@@ -3,6 +3,7 @@
  * Title: Products, 4 column with Heading
  * Slug: purple/product-related-4-column
  * Categories: purple
+ * Keywords: woo-commerce, products, related, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
  */

--- a/purple/patterns/woocommerce-single-product.php
+++ b/purple/patterns/woocommerce-single-product.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Single Product
  * Slug: purple/woocommerce-single-product
  * Categories: page, purple
+ * Keywords: woo-commerce, single product, product, page
  * Post Types: page, wp_template
  * Viewport width: 1400
  * Description: A page template for the WooCommerce single product page.

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -2,7 +2,8 @@
 /**
  * Title: Upsell products collection
  * Slug: purple/upsell-products-collection
- * Categories: call-to-action, Featured, featured-selling, woo-commerce
+ * Categories: purple
+ * Keywords: woo-commerce, products, upsell, collection
  */
 ?>
 <!-- wp:group {"metadata":{"name":"Upsell products collection"},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->


### PR DESCRIPTION
Tidies up the pattern file headers.

### Changes
- **Adds a `Keywords:` header** to inserter-visible patterns that were missing one — the WooCommerce product collections (best sellers ×2, featured, new arrivals, related, upsell), the cart / order-confirmation / single-product page patterns, the two posts-columns patterns, the footer, and coming soon.
- **Sets the upsell products pattern category to `purple`** (was a mix of `call-to-action, Featured, featured-selling, woo-commerce`).

Hidden (`Inserter: no`) patterns are intentionally left without keywords since they never appear in the inserter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
