### PR TITLE
Actually hide unwanted pattern categories from the inserter

### DIFF
--- a/purple/functions.php
+++ b/purple/functions.php
@@ -152,13 +152,14 @@ endif;
 
 add_action( 'init', 'purple_rename_woocommerce_pattern_category', 99 );
 
-if ( ! function_exists( 'purple_unregister_pattern_categories' ) ) :
+if ( ! function_exists( 'purple_hidden_pattern_categories' ) ) :
 	/**
-	 * Unregister block pattern categories the theme doesn't want to expose
-	 * in the inserter. Hooked late so it runs after core and plugins.
+	 * Block pattern categories the theme doesn't want to expose in the inserter.
+	 *
+	 * @return string[] Category slugs.
 	 */
-	function purple_unregister_pattern_categories() {
-		$categories = array(
+	function purple_hidden_pattern_categories() {
+		return array(
 			'banner',
 			'call-to-action',
 			'featured',
@@ -169,17 +170,53 @@ if ( ! function_exists( 'purple_unregister_pattern_categories' ) ) :
 			'posts',
 			'text',
 		);
-		$registry = \WP_Block_Pattern_Categories_Registry::get_instance();
-		foreach ( $categories as $cat ) {
-			if ( $registry->is_registered( $cat ) ) {
+	}
+
+endif;
+
+if ( ! function_exists( 'purple_unregister_pattern_categories' ) ) :
+	/**
+	 * Hide the pattern categories the theme doesn't want to expose.
+	 *
+	 * Unregistering a category is not enough on its own: the inserter rebuilds
+	 * a category from any pattern still tagged with it (showing the raw slug as
+	 * the label when there is no registered category). So we both unregister the
+	 * category and strip the slug from every pattern that references it.
+	 *
+	 * Hooked late so it runs after core, the theme and plugins (e.g. WooCommerce)
+	 * have registered their patterns and categories.
+	 */
+	function purple_unregister_pattern_categories() {
+		$hidden = purple_hidden_pattern_categories();
+
+		$category_registry = \WP_Block_Pattern_Categories_Registry::get_instance();
+		foreach ( $hidden as $cat ) {
+			if ( $category_registry->is_registered( $cat ) ) {
 				unregister_block_pattern_category( $cat );
 			}
+		}
+
+		$pattern_registry = \WP_Block_Patterns_Registry::get_instance();
+		foreach ( $pattern_registry->get_all_registered() as $pattern ) {
+			$categories = $pattern['categories'] ?? array();
+			if ( empty( $categories ) ) {
+				continue;
+			}
+
+			$kept = array_values( array_diff( $categories, $hidden ) );
+			if ( count( $kept ) === count( $categories ) ) {
+				continue;
+			}
+
+			$pattern['categories'] = $kept;
+			unregister_block_pattern( $pattern['name'] );
+			register_block_pattern( $pattern['name'], $pattern );
 		}
 	}
 
 endif;
 
-add_action( 'init', 'purple_unregister_pattern_categories', 99 );
+add_action( 'init', 'purple_unregister_pattern_categories', 100 );
 
 if ( ! function_exists( 'purple_styles' ) ) :
 	/**


### PR DESCRIPTION
### Problem
Strange-looking pattern categories (e.g. `featured-selling`, `call-to-action`) appeared in the inserter as raw slugs.

`purple_unregister_pattern_categories()` only unregistered the category *definitions*, but the inserter rebuilds a category from any pattern still tagged with it — falling back to the raw slug as the label. WooCommerce's bundled patterns keep referencing these slugs, so unregistering alone couldn't hide them.

### Fix
In addition to unregistering the category, **strip the hidden category slugs from the patterns themselves** (re-register each affected pattern without them). Runs at `init:100` so it executes after WooCommerce registers its patterns. The slug list is unchanged — just extracted to a shared `purple_hidden_pattern_categories()` helper.

### Result (verified on a fresh load)
- `featured-selling`, `intro`, `call-to-action` no longer appear in the inserter.
- The affected WooCommerce patterns are kept (content intact); 3 that were tagged *only* with `featured-selling` are now uncategorized (appear under "Uncategorized"/"All"); `product-collection-4-columns` stays under "Shop".
- `page` is intentionally left untouched — it's only used by 3 page-template patterns scoped via `Post Types`, so it doesn't surface in the normal inserter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
