### PR TITLE
Tidy CTA spacing and posts eyebrow styling

### DIFF
--- a/purple/patterns/cta-with-images.php
+++ b/purple/patterns/cta-with-images.php
@@ -40,7 +40,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|80","left":"var:preset|spacing|80","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|80","left":"var:preset|spacing|80","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center"} -->
 <h2 class="wp-block-heading has-text-align-center"><?php esc_html_e('A brighter, better wardrobe', 'purple');?></h2>
 <!-- /wp:heading -->

--- a/purple/patterns/posts-three-columns.php
+++ b/purple/patterns/posts-three-columns.php
@@ -9,8 +9,8 @@
  */
 ?>
 <!-- wp:group {"metadata":{"name":"List of posts in three columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.07rem"}}} -->
-<p class="has-text-align-center" style="letter-spacing:0.07rem;text-transform:uppercase"><?php esc_html_e('Journal', 'purple');?></p>
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.07rem","textAlign":"center"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"small"} -->
+<p class="has-text-align-center has-theme-2-color has-text-color has-link-color has-small-font-size" style="letter-spacing:0.07rem;text-transform:uppercase"><?php esc_html_e('Journal', 'purple');?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"var:preset|spacing|30"}}}} -->


### PR DESCRIPTION
## Summary

- **`cta-with-images`**: add a `spacing-30` block gap to the text group so the heading, paragraph and button have consistent vertical breathing room.
- **`posts-three-columns`**: style the "Journal" eyebrow paragraph with the `theme-2` color preset (text + link) and the `small` font size.

## Test plan

- Insert the CTA with images pattern and confirm the heading/text/button have even spacing.
- Insert the posts three columns pattern and confirm the "Journal" eyebrow renders in the theme-2 color at the small size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)