### PR TITLE
Rework header parts: padding over spacers, split desktop/mobile nav

### DIFF
--- a/purple/parts/checkout-header.html
+++ b/purple/parts/checkout-header.html
@@ -1,14 +1,9 @@
-<!-- wp:group {"metadata":{"name":"Checkout Header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-	
+<!-- wp:group {"metadata":{"name":"Checkout Header"},"style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"
+	style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-	<div class="wp-block-group alignwide" style="padding-top:8px;padding-bottom:8px"><!-- wp:site-title {"level":0,"style":{"typography":{"lineHeight":"1.23"}}} /--></div>
+	<div class="wp-block-group alignwide" style="padding-top:8px;padding-bottom:8px">
+		<!-- wp:site-title {"level":0,"style":{"typography":{"lineHeight":"1.23"}}} /--></div>
 	<!-- /wp:group -->
-	
-	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->

--- a/purple/parts/header-alternative.html
+++ b/purple/parts/header-alternative.html
@@ -7,7 +7,7 @@
         <div class="wp-block-columns alignwide are-vertically-aligned-center is-not-stacked-on-mobile">
             <!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
             <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
-                <!-- wp:navigation {"ref":110,"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /-->
+                <!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /-->
             </div>
             <!-- /wp:column -->
 

--- a/purple/parts/header-alternative.html
+++ b/purple/parts/header-alternative.html
@@ -1,31 +1,37 @@
-<!-- wp:group {"metadata":{"name":"Alternative header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:group {"metadata":{"name":"Alternative header"},"style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"
+    style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+    <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group alignfull">
+        <!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"align":"wide"} -->
+        <div class="wp-block-columns alignwide are-vertically-aligned-center is-not-stacked-on-mobile">
+            <!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
+            <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
+                <!-- wp:navigation {"ref":110,"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /-->
+            </div>
+            <!-- /wp:column -->
 
-<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"align":"wide"} -->
-<div class="wp-block-columns alignwide are-vertically-aligned-center is-not-stacked-on-mobile"><!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%"><!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /--></div>
-<!-- /wp:column -->
+            <!-- wp:column {"verticalAlignment":"center","width":"30%"} -->
+            <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%">
+                <!-- wp:site-title {"style":{"typography":{"textAlign":"center"}}} /--></div>
+            <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","width":"30%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:site-title {"textAlign":"center"} /--></div>
-<!-- /wp:column -->
+            <!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
+            <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
+                <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-only","buttonUseIcon":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
 
-<!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-<div class="wp-block-group"><!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+                    <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
 
-<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
-
-<!-- wp:woocommerce/mini-cart /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:group -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+                    <!-- wp:woocommerce/mini-cart /-->
+                </div>
+                <!-- /wp:group -->
+            </div>
+            <!-- /wp:column -->
+        </div>
+        <!-- /wp:columns -->
+    </div>
+    <!-- /wp:group -->
+</div>
 <!-- /wp:group -->

--- a/purple/parts/header.html
+++ b/purple/parts/header.html
@@ -1,31 +1,30 @@
-<!-- wp:group {"metadata":{"name":"Default header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-    <!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-    <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-    <!-- /wp:spacer -->
-
+<!-- wp:group {"metadata":{"name":"Default header"},"style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"
+    style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
     <!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
     <div class="wp-block-group alignwide">
         <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-        <div class="wp-block-group">
-            <!-- wp:site-title /-->
+        <div class="wp-block-group"><!-- wp:site-title /-->
 
-            <!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
+            <!-- wp:navigation {"overlayMenu":"never","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
         </div>
         <!-- /wp:group -->
 
         <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
         <div class="wp-block-group">
-            <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-only","buttonUseIcon":true,"isSearchFieldHidden":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+            <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-only","buttonUseIcon":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+
             <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
-            <!-- wp:woocommerce/mini-cart /-->
+
+            <!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+            <div class="wp-block-group"><!-- wp:woocommerce/mini-cart /-->
+
+                <!-- wp:navigation {"overlayMenu":"always","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"desktop":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"fontSize":"large","layout":{"type":"flex","flexWrap":"wrap"}} /-->
+            </div>
+            <!-- /wp:group -->
         </div>
         <!-- /wp:group -->
     </div>
     <!-- /wp:group -->
-
-    <!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-    <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-    <!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary

- **`parts/header.html`**: replace the top/bottom spacer blocks with group padding (`spacing-30`). Split the navigation into a **desktop inline nav** (`overlayMenu: never`, hidden on tablet/mobile) and a **mobile hamburger nav** (`overlayMenu: always`, hidden on desktop) grouped next to the mini-cart.
- **`parts/header-alternative.html`**: spacers → group padding; rebuilt as a three-column layout (nav / centered site title / search + account + cart).
- **`parts/checkout-header.html`**: spacers → group padding.

## Test plan

- View the default header on desktop (inline nav visible, hamburger hidden) and on mobile (hamburger visible, inline nav hidden).
- Confirm header/checkout/alternative vertical rhythm looks right with padding replacing the spacers.
- View the alternative header and confirm the three-column layout and that the nav resolves to the default menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)