### PR TITLE
Standardize product archive templates on the filters pattern; refresh cards

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -7,19 +7,18 @@
  * Description: A product grid with filters.
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Product grids with filters","patternName":"purple/product-grid-with-filters"},"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide">
 
-<!-- wp:columns {"align":"wide"} -->
+<!-- wp:group {"metadata":{"name":"Product grids with filters","patternName":"purple/product-grid-with-filters","description":"A product grid with filters.","categories":["purple"]},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:0"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"22%"} -->
-<div class="wp-block-column" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}}} -->
-<h3 class="wp-block-heading" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400;line-height:1.6"><?php esc_html_e('Filter by:', 'purple');?></h3>
+<div class="wp-block-column" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->
+<h3 class="wp-block-heading has-medium-font-size" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400;line-height:1.6"><?php esc_html_e('Filter by:', 'purple');?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"88%"} -->
-<div class="wp-block-column" style="flex-basis:88%"><!-- wp:group {"className":"alignwide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
+<div class="wp-block-column" style="flex-basis:88%"><!-- wp:group {"className":"alignwide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
@@ -32,66 +31,66 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"22%"} -->
+<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}}} -->
+<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0"><!-- wp:column {"width":"22%"} -->
 <div class="wp-block-column" style="flex-basis:22%"><!-- wp:woocommerce/product-filters {"style":{"spacing":{"blockGap":"0"}}} -->
-<div class="wp-block-woocommerce-product-filters wc-block-product-filters" style="--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff;--wc-product-filter-block-spacing:0"><!-- wp:woocommerce/accordion-group {"style":{"spacing":{"blockGap":"0"}}} -->
-<div class="wp-block-woocommerce-accordion-group"><!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"level":4,"icon":"chevron"} -->
-<h4 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span><?php esc_html_e('Price', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h4>
-<!-- /wp:woocommerce/accordion-header -->
+<div class="wp-block-woocommerce-product-filters wc-block-product-filters" style="--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff;--wc-product-filter-block-spacing:0"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
+<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]}}} -->
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4} -->
+<h4 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Price', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20","top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"},"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="margin-bottom:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:woocommerce/product-filter-price -->
+<!-- wp:accordion-panel {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20","top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"},"margin":{"bottom":"var:preset|spacing|30"}}}} -->
+<div role="region" class="wp-block-accordion-panel" style="margin-bottom:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:woocommerce/product-filter-price -->
 <div class="wp-block-woocommerce-product-filter-price"><!-- wp:woocommerce/product-filter-price-slider -->
 <div class="wp-block-woocommerce-product-filter-price-slider wc-block-product-filter-price-slider"></div>
 <!-- /wp:woocommerce/product-filter-price-slider --></div>
-<!-- /wp:woocommerce/product-filter-price --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:woocommerce/product-filter-price --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"level":4,"icon":"chevron"} -->
-<h4 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span><?php esc_html_e('Rating', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h4>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item -->
+<div class="wp-block-accordion-item"><!-- wp:accordion-heading {"level":4,"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
+<h4 class="wp-block-accordion-heading" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Rating', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-filter-rating -->
+<!-- wp:accordion-panel {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<div role="region" class="wp-block-accordion-panel" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-filter-rating -->
 <div class="wp-block-woocommerce-product-filter-rating"><!-- wp:woocommerce/product-filter-checkbox-list -->
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list --></div>
-<!-- /wp:woocommerce/product-filter-rating --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:woocommerce/product-filter-rating --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"level":4,"icon":"chevron"} -->
-<h4 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span><?php esc_html_e('Color', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h4>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item -->
+<div class="wp-block-accordion-item"><!-- wp:accordion-heading {"level":4,"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
+<h4 class="wp-block-accordion-heading" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Color', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-filter-attribute -->
+<!-- wp:accordion-panel {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<div role="region" class="wp-block-accordion-panel" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-filter-attribute -->
 <div class="wp-block-woocommerce-product-filter-attribute"><!-- wp:woocommerce/product-filter-checkbox-list -->
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list --></div>
-<!-- /wp:woocommerce/product-filter-attribute --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item -->
+<!-- /wp:woocommerce/product-filter-attribute --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->
 
-<!-- wp:woocommerce/accordion-item -->
-<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header {"level":4,"icon":"chevron"} -->
-<h4 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span><?php esc_html_e('Status', 'purple');?></span><span class="accordion-item__toggle-icon has-icon-chevron" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg></span></button></h4>
-<!-- /wp:woocommerce/accordion-header -->
+<!-- wp:accordion-item -->
+<div class="wp-block-accordion-item"><!-- wp:accordion-heading {"level":4,"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
+<h4 class="wp-block-accordion-heading" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Status', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<!-- /wp:accordion-heading -->
 
-<!-- wp:woocommerce/accordion-panel {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-filter-status -->
+<!-- wp:accordion-panel {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<div role="region" class="wp-block-accordion-panel" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-filter-status -->
 <div class="wp-block-woocommerce-product-filter-status"><!-- wp:woocommerce/product-filter-checkbox-list -->
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list --></div>
-<!-- /wp:woocommerce/product-filter-status --></div></div>
-<!-- /wp:woocommerce/accordion-panel --></div>
-<!-- /wp:woocommerce/accordion-item --></div>
-<!-- /wp:woocommerce/accordion-group -->
+<!-- /wp:woocommerce/product-filter-status --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item --></div>
+<!-- /wp:accordion -->
 
 <!-- wp:woocommerce/product-filter-active {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-woocommerce-product-filter-active" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)"><!-- wp:woocommerce/product-filter-removable-chips -->
@@ -100,8 +99,8 @@
 
 <!-- wp:woocommerce/product-filter-clear-button -->
 <!-- wp:buttons {"layout":{"type":"flex","verticalAlignment":"stretched"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","className":"wc-block-product-filter-clear-button is-style-outline","style":{"typography":{"textDecoration":"underline"},"outline":"none","fontSize":"medium","spacing":{"padding":{"left":"0px","right":"0px","top":"0px","bottom":"0px"}},"border":{"radius":"0px","width":"0px","style":"none"},"color":{"background":"#00000000"}},"fontSize":"medium"} -->
-<div class="wp-block-button wc-block-product-filter-clear-button is-style-outline"><a class="wp-block-button__link has-background has-medium-font-size has-text-align-center has-custom-font-size wp-element-button" style="border-style:none;border-width:0px;border-radius:0px;background-color:#00000000;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;text-decoration:underline"><?php esc_html_e('Clear filters', 'purple');?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"wc-block-product-filter-clear-button is-style-outline","style":{"typography":{"textDecoration":"underline","textAlign":"center"},"outline":"none","fontSize":"medium","spacing":{"padding":{"left":"0px","right":"0px","top":"0px","bottom":"0px"}},"border":{"radius":"0px","width":"0px","style":"none"},"color":{"background":"#00000000"}},"fontSize":"medium"} -->
+<div class="wp-block-button wc-block-product-filter-clear-button is-style-outline"><a class="wp-block-button__link has-background has-text-align-center has-medium-font-size has-custom-font-size wp-element-button" style="border-style:none;border-width:0px;border-radius:0px;background-color:#00000000;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;text-decoration:underline"><?php esc_html_e('Clear filters', 'purple');?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 <!-- /wp:woocommerce/product-filter-clear-button --></div>
@@ -110,37 +109,26 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"88%"} -->
-<div class="wp-block-column" style="flex-basis:88%"><!-- wp:woocommerce/product-collection {"queryId":3,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
+<div class="wp-block-column" style="flex-basis:88%"><!-- wp:woocommerce/product-collection {"queryId":27,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
-<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}},"typography":{"lineHeight":"1.5625"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /--></div>
-<!-- /wp:group -->
- <!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"<?php esc_html_e('Previous', 'purple');?>"} /-->
 
 <!-- wp:query-pagination-numbers /-->
 
 <!-- wp:query-pagination-next {"label":"<?php esc_html_e('Next', 'purple');?>"} /-->
-<!-- /wp:query-pagination -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:group -->
 
 <!-- wp:woocommerce/product-collection-no-results -->
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"wrap"}} -->
@@ -152,9 +140,5 @@ echo sprintf( esc_html__( 'No results found. You can try %1$sclearing any filter
 <!-- /wp:woocommerce/product-collection-no-results --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|80"} -->
-<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+<!-- /wp:columns --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-new-arrivals.php
+++ b/purple/patterns/woocommerce-new-arrivals.php
@@ -20,9 +20,9 @@
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0","top":"var:preset|spacing|30"}},"typography":{"lineHeight":"1.4","textAlign":"left"}},"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}},"typography":{"lineHeight":"1.5625"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-product-related-4-column.php
+++ b/purple/patterns/woocommerce-product-related-4-column.php
@@ -20,9 +20,9 @@
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}}},"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}},"typography":{"lineHeight":"1.5625"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-related-products-collection.php
+++ b/purple/patterns/woocommerce-related-products-collection.php
@@ -25,9 +25,9 @@
 <!-- wp:woocommerce/product-sale-badge /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"0"}}},"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}},"typography":{"lineHeight":"1.5625"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"left":"0","top":"var:preset|spacing|20"}}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -24,9 +24,9 @@
 <!-- wp:woocommerce/product-sale-badge /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}}},"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","left":"0"}},"typography":{"lineHeight":"1.5625"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/templates/404.html
+++ b/purple/templates/404.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"layout":{"type":"constrained","contentSize":"400px","wideSize":"720px"}} -->
 <main class="wp-block-group">
-<!-- wp:pattern {"slug":"purple/hidden-404"} /-->
-<!-- wp:pattern {"slug":"purple/product-related-4-column"} /-->
+    <!-- wp:pattern {"slug":"purple/hidden-404"} /-->
+    <!-- wp:pattern {"slug":"purple/upsell-products-collection"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/purple/templates/archive-product.html
+++ b/purple/templates/archive-product.html
@@ -1,34 +1,24 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
 
-<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
-<main class="wp-block-group alignwide is-style-default" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
+<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<main class="wp-block-group alignwide is-style-default"
+	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide"><!-- wp:woocommerce/store-notices /-->
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide">
+		<!-- wp:woocommerce/breadcrumbs /-->
 
-	<!-- wp:spacer {"height":"var:preset|spacing|60"} -->
-	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
+		<!-- wp:query-title {"type":"archive","level":2,"showPrefix":false,"align":"wide"} /-->
 
-	<!-- wp:woocommerce/store-notices /-->
-
-	<!-- wp:woocommerce/breadcrumbs /-->
-	
-	<!-- wp:query-title {"type":"archive","level":2,"showPrefix":false,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"fontSize":"xx-large"} /-->
-
-	<!-- wp:group {"align":"wide","layout":{"type":"constrained","contentSize":"740px","justifyContent":"left"}} -->
-	<div class="wp-block-group alignwide"><!-- wp:term-description /--></div>
+		<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
+		<div class="wp-block-group alignwide"><!-- wp:term-description /--></div>
+		<!-- /wp:group -->
+	</div>
 	<!-- /wp:group -->
-</div>
-<!-- /wp:group -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|60"} -->
-<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->

--- a/purple/templates/product-search-results.html
+++ b/purple/templates/product-search-results.html
@@ -1,11 +1,26 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
 
-<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
-<main class="wp-block-group alignwide is-style-default" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
+<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<main class="wp-block-group alignwide is-style-default"
+    style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide"><!-- wp:woocommerce/store-notices /-->
 
-	<!-- wp:pattern {"slug":"purple/hidden-woocommerce-product-search-results"} /-->
-	
+        <!-- wp:woocommerce/breadcrumbs /-->
+
+        <!-- wp:query-title {"type":"search","level":2,"showPrefix":false,"align":"wide"} /-->
+
+        <!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+        <div class="wp-block-group alignwide">
+            <!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search products…","buttonText":"Search","query":{"post_type":"product"},"namespace":"woocommerce/product-search"} /-->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+
+    <!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
+
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->

--- a/purple/templates/taxonomy-product_attribute.html
+++ b/purple/templates/taxonomy-product_attribute.html
@@ -1,50 +1,24 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
-<main class="wp-block-group">
-	<!-- wp:woocommerce/breadcrumbs /-->
+<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<main class="wp-block-group alignwide is-style-default"
+	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide"><!-- wp:woocommerce/store-notices /-->
 
-	<!-- wp:query-title {"type":"archive","showPrefix":false,"align":"wide"} /-->
+		<!-- wp:woocommerce/breadcrumbs /-->
 
-	<!-- wp:term-description {"align":"wide"} /-->
+		<!-- wp:query-title {"type":"archive","level":2,"showPrefix":false,"align":"wide"} /-->
 
-	<!-- wp:woocommerce/store-notices /-->
-
-	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignwide">
-		<!-- wp:woocommerce/product-results-count /-->
-
-		<!-- wp:woocommerce/catalog-sorting /-->
+		<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
+		<div class="wp-block-group alignwide"><!-- wp:term-description /--></div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","dimensions":{"widthType":"fill","fixedWidth":""},"displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"convertedFromProducts":false,"queryContextIncludes":["collection"],"align":"wide"} -->
-	<div class="wp-block-woocommerce-product-collection alignwide">
-		<!-- wp:woocommerce/product-template -->
-		<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
-			<!-- wp:woocommerce/product-sale-badge {"isDescendentOfQueryLoop":true,"align":"right"} /-->
-		<!-- /wp:woocommerce/product-image -->
-		<!-- wp:post-title {"textAlign":"center","level":2,"isLink":true,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title","style":{"typography":{"lineHeight":"1.4"}}} /-->
-		<!-- wp:woocommerce/product-price {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
-		<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
-		<!-- /wp:woocommerce/product-template -->
+	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
 
-		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-		<!-- wp:query-pagination-previous /-->
-		<!-- wp:query-pagination-numbers /-->
-		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->
-
-		<!-- wp:woocommerce/product-collection-no-results -->
-		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:pattern {"slug":"woocommerce/no-products-found-clear-filters"} /-->
-		</div>
-		<!-- /wp:group -->
-		<!-- /wp:woocommerce/product-collection-no-results -->
-	</div>
-	<!-- /wp:woocommerce/product-collection -->
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -480,10 +480,6 @@
 				}
 			},
 			"woocommerce/product-price": {
-				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--large)",
-					"lineHeight": "1.5"
-				},
 				"color": {
 					"text": "var(--wp--preset--color--theme-4)"
 				}


### PR DESCRIPTION
## Summary

Unifies the WooCommerce archive/search/taxonomy pages around the shared product-grid-with-filters pattern and refreshes the product cards.

### Templates (`archive-product`, `product-search-results`, `taxonomy-product_attribute`, `404`)
- Unify the main wrapper: full-width group with `spacing-50`/`spacing-60` padding and a consistent header block (store notices, breadcrumbs, query title, term description / product search box).
- Reuse `purple/product-grid-with-filters` for the grid on archive, search and taxonomy pages instead of bespoke inline product collections.
- `404`: swap the related-products pattern for the upsells collection.
- Add the explicit `theme` attribute to header/footer template-part refs.

### `product-grid-with-filters`
- Migrate the filter UI from the deprecated `woocommerce/accordion-*` blocks to the **core accordion blocks** (theme-6 bottom borders, `+` toggle icon).
- Replace spacer blocks with margins; tidy product card and pagination spacing.

### Product card patterns (`new-arrivals`, `product-related-4-column`, `related-products-collection`, `upsell-products-collection`)
- Product title → `medium` font size with a `1.5625` line height; drop the price's hardcoded line height.

### `theme.json`
- Drop the `woocommerce/product-price` typography override so the price size follows the card styles.

## Test plan

- View Shop (archive), a product attribute taxonomy page, and a product search results page — confirm consistent header + the filters grid renders and filters work (accordion expand/collapse, price/rating/attribute/status).
- Confirm the 404 page shows the upsells collection.
- Confirm product cards across the refreshed patterns have consistent title/price sizing and spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)