### PR TITLE
Refresh store/testimonial patterns; drop Jetpack contact-form theme.json override

### DIFF
--- a/purple/patterns/store-features-two-columns.php
+++ b/purple/patterns/store-features-two-columns.php
@@ -7,25 +7,23 @@
  * Description: A two-column section with store featured services.
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Small store features row with icons","categories":["text","about"],"patternName":"purple/store-features-two-columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-theme-5-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50)">
-
-<!-- wp:columns {"metadata":{"categories":["text","about"],"patternName":"purple/store-features-two-columns"},"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"var:preset|spacing|40"}}} -->
-<div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"width":"50%"} -->
+<!-- wp:group {"metadata":{"name":"Small store features row with icons","categories":["purple"],"patternName":"purple/store-features-two-columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-theme-5-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"metadata":{"categories":["text","about"]},"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":"32px","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.webp" alt="<?php esc_attr_e('Truck icon', 'purple');?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.webp" alt="<?php esc_attr_e('Truck icon', 'purple');?>" style="width:32px;height:auto"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1"}}} -->
-<p style="font-style:normal;font-weight:400;line-height:1"><?php esc_html_e('Free Shipping', 'purple');?></p>
+<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.5"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"medium"} -->
+<p class="has-theme-2-color has-text-color has-link-color has-medium-font-size" style="font-style:normal;font-weight:600;line-height:1.5"><?php esc_html_e('Free Shipping', 'purple');?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"}}} -->
-<p style="line-height:1"><?php esc_html_e('On all orders above 150€', 'purple');?></p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.71"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"small"} -->
+<p class="has-theme-2-color has-text-color has-link-color has-small-font-size" style="line-height:1.71"><?php esc_html_e('On all orders above 150€', 'purple');?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
@@ -35,22 +33,20 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":"32px","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.webp" alt="<?php esc_attr_e('Return icon', 'purple');?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.webp" alt="<?php esc_attr_e('Return icon', 'purple');?>" style="width:32px;height:auto"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","verticalAlignment":"space-between"}} -->
-<div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1"}}} -->
-<p style="font-style:normal;font-weight:400;line-height:1"><?php esc_html_e('Easy Returns', 'purple');?></p>
+<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.5"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"medium"} -->
+<p class="has-theme-2-color has-text-color has-link-color has-medium-font-size" style="font-style:normal;font-weight:600;line-height:1.5"><?php esc_html_e('Easy Returns', 'purple');?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"}}} -->
-<p style="line-height:1"><?php esc_html_e('40-day extended returns', 'purple');?></p>
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.71"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"small"} -->
+<p class="has-theme-2-color has-text-color has-link-color has-small-font-size" style="line-height:1.71"><?php esc_html_e('40-day extended returns', 'purple');?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-</div>
+<!-- /wp:columns --></div>
 <!-- /wp:group -->

--- a/purple/patterns/store-footer-2.php
+++ b/purple/patterns/store-footer-2.php
@@ -7,8 +7,8 @@
  * Description: A three-column store footer with site title and address, contact info, social links, and a bottom row with legal links and copyright.
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Store Footer"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} -->
+<!-- wp:group {"metadata":{"name":"Store Footer"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"10px","padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:site-title {"level":0} /-->

--- a/purple/patterns/subscribe-to-newsletter.php
+++ b/purple/patterns/subscribe-to-newsletter.php
@@ -7,14 +7,11 @@
  * Description: A section with a heading and a newsletter subscription form.
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Subscribe to newsletter section"},"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
 
-<!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading -->
+<!-- wp:group {"metadata":{"name":"Subscribe to newsletter section","categories":["purple"],"patternName":"purple/subscribe-to-newsletter"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading -->
 <h2 class="wp-block-heading"><?php esc_html_e('Subscribe to our newsletter', 'purple');?></h2>
 <!-- /wp:heading -->
 
@@ -23,16 +20,8 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:jetpack/contact-form {"className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-jetpack-contact-form is-style-default" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:jetpack/field-email {"label":"","required":true,"requiredText":"","placeholder":"<?php esc_html_e('Your email', 'purple');?>","width":75,"borderRadius":0,"borderWidth":1,"labelFontSize":"14px"} /-->
-
-<!-- wp:jetpack/button {"element":"button","text":"<?php esc_html_e('Subscribe', 'purple');?>","borderRadius":0,"width":"150px","lock":{"move":true,"remove":true}} /--></div>
-<!-- /wp:jetpack/contact-form --></div>
+<!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:jetpack/contact-form {"jetpackCRM":false,"variationName":"default","salesforceData":{"organizationId":"","sendToSalesforce":false},"mailpoet":{"listId":null,"listName":null,"enabledForForm":false},"layout":{"type":"flex","flexWrap":"nowrap","orientation":"horizontal","justifyContent":"left","verticalAlignment":"bottom"}} /--></div>
 <!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+<!-- /wp:columns --></div>
 <!-- /wp:group -->

--- a/purple/patterns/testimonial-with-logo.php
+++ b/purple/patterns/testimonial-with-logo.php
@@ -7,24 +7,17 @@
  * Description: A testimonial with centered text and a logo.
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Testimonial with logo"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-theme-5-background-color has-background" style="padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.07rem","fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} -->
-<h2 class="wp-block-heading has-text-align-center has-small-font-size" style="font-style:normal;font-weight:400;letter-spacing:0.07rem;text-transform:uppercase"><?php esc_html_e('In the press', 'purple');?></h2>
+
+<!-- wp:group {"metadata":{"name":"Testimonial with logo","categories":["testimonials","purple"],"patternName":"purple/testimonial-with-logo"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-theme-5-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08rem","textAlign":"center","fontStyle":"normal","fontWeight":"300"}},"fontSize":"small"} -->
+<h2 class="wp-block-heading has-text-align-center has-small-font-size" style="font-style:normal;font-weight:300;letter-spacing:0.08rem;text-transform:uppercase"><?php esc_html_e('In the press', 'purple');?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
-<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center"><?php esc_html_e('“With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.”', 'purple');?></p>
+<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"},"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size" style="margin-top:var(--wp--preset--spacing--60)"><?php esc_html_e('“With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.”', 'purple');?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:image {"width":"130px","sizeSlug":"full","linkDestination":"none","align":"center"} -->
-<figure class="wp-block-image aligncenter size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/logo-3.webp" alt="<?php esc_attr_e('Brand logo', 'purple');?>" class="" style="width:130px"/></figure>
+<!-- wp:image {"width":"130px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<figure class="wp-block-image aligncenter size-full is-resized" style="margin-top:var(--wp--preset--spacing--50)"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/logo-3.webp" alt="<?php esc_attr_e('Brand logo', 'purple');?>" style="width:130px;height:auto"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -397,12 +397,6 @@
 					"text": "var(--wp--preset--color--theme-4)"
 				}
 			},
-			"jetpack/contact-form": {
-				"border": {
-					"radius": "0"
-				},
-				"css": ".contact-form input[type=text], .contact-form input[type=email], .contact-form input[type=tel], .contact-form input[type=url], .contact-form input[type=number], .contact-form textarea { padding:calc(0.75em - 1px) calc(var(--wp--preset--spacing--30) - 1px); }"
-			},
 			"woocommerce/product-title": {
 				"typography": {
 					"fontSize":  "var(--wp--preset--font-size--large)",


### PR DESCRIPTION
## Summary

- **`theme.json`**: remove the `jetpack/contact-form` style block (the `border-radius:0` and the custom input-padding `css` rule). That rule was being compiled into `global-styles-inline-css` and applied to all Jetpack form inputs; inputs now use Jetpack's own default styling.
- **`subscribe-to-newsletter`**: replace spacer blocks with group padding (`spacing-60`), vertically center the columns, and use the default `jetpack/contact-form` variation instead of hand-rolled field/button markup.
- **`store-features-two-columns`**: fix the inserter category, tidy spacing/blockGap, and set the feature labels/sublabels to the `theme-2` color with `medium`/`small` font sizes.
- **`store-footer-2`**: increase top/bottom padding from `spacing-30` to `spacing-60`.
- **`testimonial-with-logo`**: spacers → margins, large centered quote, lighter (weight 300) uppercase eyebrow, and add pattern category metadata.

## Context

The `theme.json` change resolves a reported issue where a Jetpack form input padding rule (`padding: calc(0.75em - 1px) calc(var(--wp--preset--spacing--30) - 1px)`) loaded only under this theme — it originated from this `styles.blocks["jetpack/contact-form"].css` entry.

## Test plan

- View the subscribe-to-newsletter pattern and confirm the form renders with Jetpack's default input styling (no leftover custom padding).
- Insert the store-features, store-footer, and testimonial-with-logo patterns and confirm spacing/typography look right.
- Confirm store-features appears under the correct inserter category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)