### PR TITLE
Hide product grid with filters pattern from the inserter

### DIFF
--- a/purple/patterns/hidden-product-grid-with-filters.php
+++ b/purple/patterns/hidden-product-grid-with-filters.php
@@ -1,14 +1,12 @@
 <?php
 /**
- * Title: Product grids with filters
- * Slug: purple/product-grid-with-filters
- * Categories: purple
- * Keywords: woo-commerce, product, grid, filters
- * Description: A product grid with filters.
+ * Title: Hidden product grid with filters
+ * Slug: purple/hidden-product-grid-with-filters
+ * Inserter: no
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Product grids with filters","patternName":"purple/product-grid-with-filters","description":"A product grid with filters.","categories":["purple"]},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Product grids with filters","patternName":"purple/hidden-product-grid-with-filters"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:0"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"22%"} -->
 <div class="wp-block-column" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->

--- a/purple/templates/archive-product.html
+++ b/purple/templates/archive-product.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/product-search-results.html
+++ b/purple/templates/product-search-results.html
@@ -18,7 +18,7 @@
     </div>
     <!-- /wp:group -->
 
-    <!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
+    <!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/taxonomy-product_attribute.html
+++ b/purple/templates/taxonomy-product_attribute.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- Renames `product-grid-with-filters` to `hidden-product-grid-with-filters` and marks it `Inserter: no`
- Updates shop archive, product search, and product attribute taxonomy templates to reference the new slug

This pattern includes `woocommerce/product-results-count` and `woocommerce/catalog-sorting`, which WooCommerce deliberately does not register in the post/page editor. Keeping it in the general inserter led to unsupported-block errors when merchants tried to insert it outside the Site Editor.

## Test plan
- [ ] Confirm the pattern no longer appears in the post/page block inserter
- [ ] Shop archive (`/shop/`) still renders filters, sort, results count, and product grid
- [ ] Product search results template still renders the grid
- [ ] Product attribute taxonomy archive still renders the grid
- [ ] Site Editor templates for archive/search/taxonomy open without broken pattern references


Made with [Cursor](https://cursor.com)