### PR TITLE
Set table block borders to theme-6

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -376,6 +376,9 @@
 					"text": "var(--wp--preset--color--theme-6)"
 				}
 			},
+			"core/table": {
+				"css": "& td, & th { border-color: var(--wp--preset--color--theme-6); }"
+			},
 			"core/site-title": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-2)"
@@ -546,7 +549,7 @@
 			"background": "var(--wp--preset--color--theme-1)",
 			"text": "var(--wp--preset--color--theme-4)"
 		},
-		"css": "",
+		"css": ".wp-block-table td, .wp-block-table th { border-color: var(--wp--preset--color--theme-6); } .wp-block-table th { font-weight: 600; }",
 		"elements": {
 			"button": {
 				":hover": {


### PR DESCRIPTION
## Summary
- Set `core/table` cell borders to the `theme-6` color preset via `theme.json` root `styles.css`, matching separators and accordion dividers.
- Add `font-weight: 600` for table header cells in the same global rule.

## Test plan
- [ ] Open a page with the Size chart pattern (`purple/size-chart`) and confirm table borders use the light `theme-6` gray.
- [ ] Check a product page Additional Information accordion and confirm product specification tables still look correct.
- [ ] Confirm borders look the same in the editor and on the front end.


Made with [Cursor](https://cursor.com)