### PR TITLE
Polish single product page and refresh footer patterns

### DIFF
--- a/purple/parts/footer-alternative.html
+++ b/purple/parts/footer-alternative.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"purple/footer-alternative"} /-->

--- a/purple/parts/variable-product-add-to-cart-with-options.html
+++ b/purple/parts/variable-product-add-to-cart-with-options.html
@@ -1,36 +1,22 @@
 <!-- wp:woocommerce/add-to-cart-with-options-variation-selector -->
-<div
-	class="wp-block-woocommerce-add-to-cart-with-options-variation-selector"
-	role="list"
->
-	<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
-	<div
-		class="wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute"
-		role="listitem"
-	>
-		<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-		<div
-			class="wp-block-group"
-			style="margin-top: 1rem; margin-bottom: 1rem"
-		>
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
+<div class="wp-block-woocommerce-add-to-cart-with-options-variation-selector" role="list"><!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
+	<div class="wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute" role="listitem"><!-- wp:group {"lock":{"move":false,"remove":false},"style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
+	
+	<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /--></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute --></div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
+	
+	<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+	
+	<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+	
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"stretch"}} -->
+	<div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector /-->
+	
+	<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+	 
+	<!-- /wp:group -->
+	
 
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector-attribute -->
-</div>
-<!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
-
-<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-
-<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"stretch"}} -->
-<div class="wp-block-group">
-	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-
-	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
-</div>
-<!-- /wp:group -->

--- a/purple/patterns/footer-alternative.php
+++ b/purple/patterns/footer-alternative.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Store footer 2
- * Slug: purple/store-footer-2
+ * Title: Footer alternative
+ * Slug: purple/footer-alternative
  * Categories: footer
  * Keywords: footer, contact, social, links
  * Description: A three-column store footer with site title and address, contact info, social links, and a bottom row with legal links and copyright.
@@ -69,14 +69,14 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:paragraph {"style":{"typography":{"textAlign":"left"}}} -->
-<p class="has-text-align-left">&copy; <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php
-	/* Translators: WordPress link. */
-	$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'purple' ) ) . '" rel="nofollow">WordPress</a>';
+<!-- wp:paragraph {"className":"underline-link","style":{"typography":{"textAlign":"left"},"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} -->
+<p class="has-text-align-left underline-link has-theme-4-color has-text-color has-link-color has-small-font-size">&copy; <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php
+	/* Translators: WooCommerce link. */
+	$woocommerce_link = '<a href="' . esc_url( __( 'https://woocommerce.com/', 'purple' ) ) . '" rel="nofollow">WooCommerce</a>';
 	echo sprintf(
-		/* Translators: Designed with WordPress */
+		/* Translators: Designed with WooCommerce */
 		esc_html__( 'All rights reserved. Designed with %1$s.', 'purple' ),
-		$wordpress_link
+		$woocommerce_link
 	);
 	?></p>
 <!-- /wp:paragraph --></div>

--- a/purple/patterns/footer.php
+++ b/purple/patterns/footer.php
@@ -77,14 +77,14 @@
 
 <!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"300","textTransform":"none","letterSpacing":"0px"},"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} /-->
 
-<!-- wp:paragraph {"style":{"typography":{"textAlign":"left"},"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"fontSize":"small"} -->
-<p class="has-text-align-left has-link-color has-small-font-size"><?php
-	/* Translators: WordPress link. */
-	$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'purple' ) ) . '" rel="nofollow">WordPress</a>';
+<!-- wp:paragraph {"className":"underline-link","style":{"typography":{"textAlign":"left"},"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} -->
+<p class="has-text-align-left underline-link has-theme-4-color has-text-color has-link-color has-small-font-size"><?php
+	/* Translators: WooCommerce link. */
+	$woocommerce_link = '<a href="' . esc_url( __( 'https://woocommerce.com/', 'purple' ) ) . '" rel="nofollow">WooCommerce</a>';
 	echo sprintf(
-		/* Translators: Designed with WordPress */
-		esc_html__( 'Designed with %1$s', 'purple' ),
-		$wordpress_link
+		/* Translators: Designed with WooCommerce */
+		esc_html__( 'All rights reserved. Designed with %1$s.', 'purple' ),
+		$woocommerce_link
 	);
 	?></p>
 <!-- /wp:paragraph --></div>

--- a/purple/patterns/hidden-single-product.php
+++ b/purple/patterns/hidden-single-product.php
@@ -31,8 +31,8 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:post-title {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"x-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)"><!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"0"}}}} /-->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"},"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--10)"><!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"fontSize":"large","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"0"}}}} /-->
 
 <!-- wp:woocommerce/product-sale-badge /--></div>
 <!-- /wp:group -->
@@ -85,13 +85,13 @@
 
 <!-- wp:pattern {"slug":"purple/categories-on-three-columns"} /-->
 
-<!-- wp:group {"metadata":{"name":"Product reviews"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"","wideSize":"49rem"}} -->
-<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40)"><!-- wp:woocommerce/product-reviews -->
-<div class="wp-block-woocommerce-product-reviews"><!-- wp:woocommerce/product-reviews-title {"showProductTitle":false,"showReviewsCount":false,"level":3,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
+<!-- wp:group {"metadata":{"name":"Product reviews"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"48.75rem","wideSize":"48.75rem"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:woocommerce/product-reviews -->
+<div class="wp-block-woocommerce-product-reviews"><!-- wp:woocommerce/product-reviews-title {"showProductTitle":false,"showReviewsCount":false,"level":3,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"fontSize":"x-large"} /-->
 
 <!-- wp:woocommerce/product-review-template -->
-<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-columns"><!-- wp:column {"width":"140px"} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-columns" style="margin-top:0;margin-bottom:0"><!-- wp:column {"width":"140px"} -->
 <div class="wp-block-column" style="flex-basis:140px"><!-- wp:woocommerce/product-review-author-name {"isLink":false,"style":{"spacing":{"padding":{"bottom":"0","top":"0.25em"}}}} /--></div>
 <!-- /wp:column -->
 
@@ -108,19 +108,17 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|60"} -->
-<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
+<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 <!-- /wp:woocommerce/product-review-template -->
 
-<!-- wp:woocommerce/product-reviews-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<!-- wp:woocommerce/product-reviews-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <!-- wp:woocommerce/product-reviews-pagination-previous /-->
 
 <!-- wp:woocommerce/product-reviews-pagination-next /-->
 <!-- /wp:woocommerce/product-reviews-pagination -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:woocommerce/product-review-form /--></div>
-<!-- /wp:group --></div>
+<!-- wp:woocommerce/product-review-form {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /--></div>
 <!-- /wp:woocommerce/product-reviews --></div>
 <!-- /wp:group -->

--- a/purple/patterns/page-coming-soon.php
+++ b/purple/patterns/page-coming-soon.php
@@ -28,12 +28,14 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp","alt":"<?php esc_attr_e( 'Placeholder image', 'purple' ); ?>","dimRatio":40,"isUserOverlayColor":true,"minHeight":100,"minHeightUnit":"vh","contentPosition":"bottom right","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30","top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"color":[]},"layout":{"type":"default"}} -->
 <div class="wp-block-cover has-custom-content-position is-position-bottom-right" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30);min-height:100vh"><img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim-40 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"className":"underline-link","style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-1"}}},"typography":{"lineHeight":"1.71"}},"fontSize":"small"} -->
 <p class="underline-link has-link-color has-small-font-size" style="line-height:1.71"><?php
-echo sprintf(
-	esc_html__( 'Built with %1$sWooCommerce%2$s', 'purple' ),
-	'<a href="' . esc_url( 'https://woocommerce.com/' ) . '">',
-	'</a>'
-);
-?></p>
+	/* Translators: WooCommerce link. */
+	$woocommerce_link = '<a href="' . esc_url( __( 'https://woocommerce.com/', 'purple' ) ) . '" rel="nofollow">WooCommerce</a>';
+	echo sprintf(
+		/* Translators: Designed with WooCommerce */
+		esc_html__( 'All rights reserved. Designed with %1$s.', 'purple' ),
+		$woocommerce_link
+	);
+	?></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover --></div>
 <!-- /wp:column --></div>

--- a/purple/style.css
+++ b/purple/style.css
@@ -64,6 +64,11 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
     align-items: flex-start;
 }
 
+.wc-block-components-quantity-selector {
+    border-color: var(--wp--preset--color--theme-6);
+    border-radius: 0;
+}
+
 /* Catalog sort order select — CSS customizable select (base-select).
  * Continues PR #82 exploration: https://github.com/woocommerce/woo-themes/pull/82
  * Closed/open styles from Figma Dropdown/Default (1:6531) and Dropdown/Open Links (37:1153).
@@ -207,6 +212,42 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
     .woocommerce.wc-block-catalog-sorting select.orderby:open selectedcontent {
         text-decoration: underline;
     }
+}
+
+:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pills) {
+    gap: var(--wp--preset--spacing--20);
+}
+
+:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill) {
+    border-color: var(--wp--preset--color--theme-4);
+    border-radius: 0;
+    font-size: var(--wp--preset--font-size--small);
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    line-height: 1.142;
+    padding: var(--wp--preset--spacing--20) var(--wp--preset--spacing--30);
+    text-transform: uppercase;
+}
+
+.woocommerce-page label.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
+    margin-bottom: 0;
+}
+
+.woocommerce-page label.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name {
+    margin-bottom: 0;
+}
+
+:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked)) {
+    background-color: var(--wp--preset--color--theme-2);
+}
+
+.wp-block-accordion-heading__toggle:hover .wp-block-accordion-heading__toggle-title {
+    text-decoration: none;
+}
+
+.wp-block-woocommerce-product-review-content p {
+    margin-top: var(--wp--preset--spacing--30);
+    margin-bottom: 0;
 }
 
 /* Navigation dropdown panel — desktop only.

--- a/purple/templates/single-product.html
+++ b/purple/templates/single-product.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:0">
+<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0"},"padding":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:0;padding-bottom:var(--wp--preset--spacing--70)">
 	
     <!-- wp:pattern {"slug":"purple/hidden-single-product"} /-->
 

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -707,6 +707,11 @@
 			"area": "footer",
 			"name": "footer",
 			"title": "Footer"
+		},
+		{
+			"area": "footer",
+			"name": "footer-alternative",
+			"title": "Footer alternative"
 		}
 	],
 	"version": 3,


### PR DESCRIPTION
## Summary
- Polish the single product template: price spacing and size, reviews section layout, pagination arrows, and bottom padding.
- Style variable product add-to-cart UI (variation pills, quantity selector) and review/accordion details in `style.css`.
- Rename `store-footer-2` to `footer-alternative`, register it as a footer template part, and align footer/coming-soon credits with WooCommerce branding.

## Test plan
- [ ] Open a single product page and verify price, sale badge, variation pills, quantity selector, and add-to-cart layout.
- [ ] Scroll to reviews: check title size, review spacing, pagination arrows, and review form margin.
- [ ] Confirm default footer shows "All rights reserved. Designed with WooCommerce." with underline-link styling.
- [ ] Switch to the Footer alternative template part and verify layout and copyright line.
- [ ] Open the Coming Soon page pattern and verify the footer credit text matches.


Made with [Cursor](https://cursor.com)