### PR TITLE
Purple: pattern header batch 1 fixes

### DIFF
--- a/purple/patterns/about-category-collection.php
+++ b/purple/patterns/about-category-collection.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Collection of categories with images	
+ * Title: Collection of categories with images
  * Slug: purple/about-category-collection
  * Categories: purple
  * Keywords: about, text, image, media

--- a/purple/patterns/about-left-aligned-heading-text-and-button-right-image.php
+++ b/purple/patterns/about-left-aligned-heading-text-and-button-right-image.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Left-aligned heading, text and button, image  on the right
+ * Title: Left-aligned heading, text and button, image on the right
  * Slug: purple/about-left-aligned-heading-text-and-button-right-image
  * Categories: about
  * Keywords: about, intro, heading, image, button

--- a/purple/patterns/categories-on-three-columns.php
+++ b/purple/patterns/categories-on-three-columns.php
@@ -3,7 +3,7 @@
  * Title: Categories on three columns
  * Slug: purple/categories-on-three-columns
  * Categories: woo-commerce, purple
- * Keywords: text, media, columns	
+ * Keywords: text, media, columns
  * Description: A section with three columns of categories with images.
  * Viewport width: 1440
  */

--- a/purple/patterns/footer-alternative.php
+++ b/purple/patterns/footer-alternative.php
@@ -4,6 +4,7 @@
  * Slug: purple/footer-alternative
  * Categories: footer
  * Keywords: footer, contact, social, links
+ * Block Types: core/template-part/footer
  * Description: A three-column store footer with site title and address, contact info, social links, and a bottom row with legal links and copyright.
  * Viewport width: 1440
  */

--- a/purple/patterns/new-arrival-product.php
+++ b/purple/patterns/new-arrival-product.php
@@ -3,7 +3,7 @@
  * Title: New arrival product
  * Slug: purple/new-arrival-product
  * Categories: purple
- * Keywords: woo-commerce, featured, featured-selling, call-to-action
+ * Keywords: woo-commerce, new arrival, product, featured
  * Description: A new arrival product with a featured image, title, description and button.
  * Viewport width: 1440
  */

--- a/purple/patterns/page-home-alternative-2.php
+++ b/purple/patterns/page-home-alternative-2.php
@@ -13,5 +13,5 @@
 <!-- wp:pattern {"slug":"purple/two-columns-full-width-categories"} /-->
 <!-- wp:pattern {"slug":"purple/new-arrival-product"} /-->
 <!-- wp:pattern {"slug":"purple/woocommerce-featured-products"} /-->
-<!-- wp:pattern {"slug":"purple/left-aligned-image-description-button"} /-->
+<!-- wp:pattern {"slug":"purple/about-left-aligned-image-description-button"} /-->
 <!-- wp:pattern {"slug":"purple/store-features-four-columns-alternative"} /-->

--- a/purple/patterns/two-columns-highlights-sections.php
+++ b/purple/patterns/two-columns-highlights-sections.php
@@ -4,7 +4,7 @@
  * Slug: purple/two-columns-highlights-sections
  * Categories: purple
  * Keywords: about, columns, media, featured
- * Description: A section with 2 columns of highlights
+ * Description: A section with 2 columns of highlights.
  * Viewport width: 1440
  */
 ?>

--- a/purple/patterns/woocommerce-best-sellers-3-columns.php
+++ b/purple/patterns/woocommerce-best-sellers-3-columns.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Best Sellers Collection
+ * Title: Best sellers collection, 3 columns
  * Slug: purple/woocommerce-best-sellers-3-columns
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, best sellers, collection

--- a/purple/patterns/woocommerce-best-sellers.php
+++ b/purple/patterns/woocommerce-best-sellers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Best Sellers Collection
+ * Title: Best sellers collection, 4 columns
  * Slug: purple/woocommerce-best-sellers
  * Categories: purple
  * Keywords: woo-commerce, products, best sellers, collection

--- a/purple/patterns/woocommerce-related-products-collection.php
+++ b/purple/patterns/woocommerce-related-products-collection.php
@@ -3,7 +3,8 @@
  * Title: Related products collection
  * Slug: purple/related-products-collection
  * Categories: purple
- * Keywords: woo-commerce, featured, featured-selling, call-to-action
+ * Keywords: woo-commerce, products, related, collection
+ * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a carousel of related products.
  * Viewport width: 1440
  */

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -4,6 +4,8 @@
  * Slug: purple/upsell-products-collection
  * Categories: purple
  * Keywords: woo-commerce, products, upsell, collection
+ * Block Types: woocommerce/product-collection
+ * Description: A section with a heading and a carousel of upsell products.
  * Viewport width: 1440
  */
 ?>


### PR DESCRIPTION
## Summary
- Add missing `Description` and `Block Types` to upsell/related product collection patterns; add `Block Types` to `footer-alternative`.
- Fix copy-pasted keywords on related products and new arrival patterns.
- Differentiate duplicate “Best sellers collection” inserter titles (3 vs 4 columns).
- Clean up title/keyword typos (double space, trailing tabs, missing period).
- Fix `page-home-alternative-2` referencing non-existent `purple/left-aligned-image-description-button` slug.

## Test plan
- [ ] Inserter: confirm upsell/related/footer-alternative patterns still appear and preview correctly.
- [ ] Inserter: confirm best sellers patterns show distinct titles.
- [ ] Site Editor: insert **Shop homepage alternative 2** and verify all nested patterns render (especially the image/description section).

Made with [Cursor](https://cursor.com)