### PR TITLE
Purple: pattern header batch 2 — category normalization

### DIFF
--- a/purple/patterns/about-left-aligned-heading-text-and-button-right-image.php
+++ b/purple/patterns/about-left-aligned-heading-text-and-button-right-image.php
@@ -2,14 +2,14 @@
 /**
  * Title: Left-aligned heading, text and button, image on the right
  * Slug: purple/about-left-aligned-heading-text-and-button-right-image
- * Categories: about
+ * Categories: about, purple
  * Keywords: about, intro, heading, image, button
  * Description: A two-column about section with text on one side and an image placeholder on the other.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"About","categories":["about"],"patternName":"purple/about-left-aligned-heading-text-and-button-right-image"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"name":"About","categories":["about","purple"],"patternName":"purple/about-left-aligned-heading-text-and-button-right-image"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","layout":{"type":"constrained","contentSize":"580px","justifyContent":"left"}} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"x-large"} -->

--- a/purple/patterns/about-three-columns-of-images-with-heading-and-paragraph.php
+++ b/purple/patterns/about-three-columns-of-images-with-heading-and-paragraph.php
@@ -2,14 +2,14 @@
 /**
  * Title: Three columns of images with heading and paragraph
  * Slug: purple/about-three-columns-of-images-with-heading-and-paragraph
- * Categories: about
+ * Categories: about, purple
  * Keywords: about, intro, columns, heading
  * Description: A section with a heading and short paragraph above a row of three image placeholders.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Three columns of images with heading and paragraph","categories":["about"],"patternName":"purple/about-three-columns-of-images-with-heading-and-paragraph"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"name":"Three columns of images with heading and paragraph","categories":["about","purple"],"patternName":"purple/about-three-columns-of-images-with-heading-and-paragraph"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":"16rem"}} -->
 <div class="wp-block-group alignwide"><!-- wp:heading {"align":"wide","style":{"layout":{"columnSpan":2}}} -->
 <h2 class="wp-block-heading alignwide"><?php esc_html_e( 'A world filled with boundless potential', 'purple' ); ?></h2>

--- a/purple/patterns/categories-on-three-columns.php
+++ b/purple/patterns/categories-on-three-columns.php
@@ -8,7 +8,7 @@
  * Viewport width: 1440
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Categories on three columns","patternName":"purple/categories-on-three-columns","description":"A section with three columns of categories with images.","categories":["text","media","columns"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Categories on three columns","patternName":"purple/categories-on-three-columns","description":"A section with three columns of categories with images.","categories":["woo-commerce","purple"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/product-view3.webp","alt":"<?php esc_attr_e( 'Illustration of a folded shirt', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->

--- a/purple/patterns/contact-form-with-address-and-image.php
+++ b/purple/patterns/contact-form-with-address-and-image.php
@@ -2,13 +2,13 @@
 /**
  * Title: Contact form with address and image
  * Slug: purple/contact-form-with-address-and-image
- * Categories: about, contact
+ * Categories: about, contact, purple
  * Keywords: contact, form, contact-form, address
  * Description: A contact section with heading, address, contact form, and image placeholder.
  * Viewport width: 1440
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Contact","categories":["about","contact"],"patternName":"purple/contact-form-with-address-and-image"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"name":"Contact","categories":["about","contact","purple"],"patternName":"purple/contact-form-with-address-and-image"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":""} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading -->

--- a/purple/patterns/footer-alternative.php
+++ b/purple/patterns/footer-alternative.php
@@ -2,7 +2,7 @@
 /**
  * Title: Footer alternative
  * Slug: purple/footer-alternative
- * Categories: footer
+ * Categories: footer, purple
  * Keywords: footer, contact, social, links
  * Block Types: core/template-part/footer
  * Description: A three-column store footer with site title and address, contact info, social links, and a bottom row with legal links and copyright.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Store Footer","categories":["footer"],"patternName":"purple/footer-alternative"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Store Footer","categories":["footer","purple"],"patternName":"purple/footer-alternative"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:site-title {"level":0} /-->

--- a/purple/patterns/new-arrival-product.php
+++ b/purple/patterns/new-arrival-product.php
@@ -2,14 +2,14 @@
 /**
  * Title: New arrival product
  * Slug: purple/new-arrival-product
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, new arrival, product, featured
  * Description: A new arrival product with a featured image, title, description and button.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"New arrival product","patternName":"purple/new-arrival-product","description":"A new arrival product with a featured image, title, description and button.","categories":["purple"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"New arrival product","patternName":"purple/new-arrival-product","description":"A new arrival product with a featured image, title, description and button.","categories":["woo-commerce","purple"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-theme-5-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:image {"width":"220px","aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none","align":"center"} -->
 <figure class="wp-block-image aligncenter size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/socks.webp" alt="<?php esc_attr_e( 'Placeholder image', 'purple' ); ?>" style="aspect-ratio:3/4;object-fit:cover;width:220px;height:auto"/></figure>
 <!-- /wp:image -->

--- a/purple/patterns/reviews-heading-left.php
+++ b/purple/patterns/reviews-heading-left.php
@@ -2,13 +2,13 @@
 /**
  * Title: Review: Heading on left, two columns of reviews on right
  * Slug: purple/reviews-heading-left
- * Categories: testimonials
+ * Categories: testimonials, purple
  * Keywords: reviews, testimonials, ratings, stars, columns
  * Description: A reviews section with the heading on the left and two columns containing four customer reviews on the right.
  * Viewport width: 1440
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Reviews","categories":["testimonials"],"patternName":"purple/reviews-heading-left"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"name":"Reviews","categories":["testimonials","purple"],"patternName":"purple/reviews-heading-left"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"metadata":{"name":"Items"},"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:heading {"style":{"layout":{"selfStretch":"fixed","flexSize":"100%"}}} -->

--- a/purple/patterns/reviews-three-columns.php
+++ b/purple/patterns/reviews-three-columns.php
@@ -2,13 +2,13 @@
 /**
  * Title: Reviews three columns
  * Slug: purple/reviews-three-columns
- * Categories: testimonials
+ * Categories: testimonials, purple
  * Keywords: reviews, testimonials, ratings, stars
  * Description: A three-column reviews section with star ratings, review text, and reviewer name.
  * Viewport width: 1440
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Reviews","categories":["testimonials"],"patternName":"purple/reviews-three-columns"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"name":"Reviews","categories":["testimonials","purple"],"patternName":"purple/reviews-three-columns"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"wide","style":{"typography":{"textAlign":"left"}}} -->
 <h2 class="wp-block-heading has-text-align-left alignwide"><?php esc_html_e( 'Reviews', 'purple' ); ?></h2>
 <!-- /wp:heading -->

--- a/purple/patterns/size-chart.php
+++ b/purple/patterns/size-chart.php
@@ -2,7 +2,7 @@
 /**
  * Title: Size chart
  * Slug: purple/size-chart
- * Categories: woo-commerce
+ * Categories: woo-commerce, purple
  * Keywords: size chart, table
  * Description: A size chart table.
  * Block Types: core/table

--- a/purple/patterns/woocommerce-best-sellers.php
+++ b/purple/patterns/woocommerce-best-sellers.php
@@ -2,7 +2,7 @@
 /**
  * Title: Best sellers collection, 4 columns
  * Slug: purple/woocommerce-best-sellers
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, best sellers, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["purple"],"name":"Best Sellers Collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-best-sellers"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"name":"Best Sellers Collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-best-sellers"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":56,"query":{"perPage":4,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"popularity","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/best-sellers","hideControls":["inherit","order","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"style":{"typography":{"textAlign":"center","lineHeight":"1.21"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"x-large"} --><h2 class="wp-block-heading has-text-align-center has-x-large-font-size" style="margin-top:0;margin-bottom:0;line-height:1.21"><?php esc_html_e('Best sellers', 'purple');?></h2>
 <!-- /wp:heading -->

--- a/purple/patterns/woocommerce-featured-products.php
+++ b/purple/patterns/woocommerce-featured-products.php
@@ -2,7 +2,7 @@
 /**
  * Title: Featured products
  * Slug: purple/woocommerce-featured-products
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, featured, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Featured products","categories":["purple"],"patternName":"purple/woocommerce-featured-products","description":"A section with a heading and a 4 column product grid."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Featured products","categories":["woo-commerce","purple"],"patternName":"purple/woocommerce-featured-products","description":"A section with a heading and a 4 column product grid."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":47,"query":{"perPage":8,"pages":"1","offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/featured","hideControls":["inherit","featured","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"style":{"typography":{"textAlign":"left"}},"fontSize":"x-large"} -->
 <h2 class="wp-block-heading has-text-align-left has-x-large-font-size"><?php esc_html_e('Featured products', 'purple');?></h2>

--- a/purple/patterns/woocommerce-new-arrivals.php
+++ b/purple/patterns/woocommerce-new-arrivals.php
@@ -2,7 +2,7 @@
 /**
  * Title: New Arrivals Collection
  * Slug: purple/woocommerce-new-arrivals
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, new arrivals, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["purple"],"name":"New Arrivals Collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-new-arrivals"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"name":"New Arrivals Collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-new-arrivals"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":5,"query":{"perPage":4,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"timeFrame":{"operator":"not-in","value":"-7 days"},"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/new-arrivals","hideControls":["inherit","order","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"style":{"typography":{"textAlign":"center","lineHeight":"1.21"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"x-large"} --><h2 class="wp-block-heading has-text-align-center has-x-large-font-size" style="margin-top:0;margin-bottom:0;line-height:1.21"><?php esc_html_e('New arrivals', 'purple');?></h2>
 <!-- /wp:heading -->

--- a/purple/patterns/woocommerce-product-related-4-column.php
+++ b/purple/patterns/woocommerce-product-related-4-column.php
@@ -2,7 +2,7 @@
 /**
  * Title: Products, 4 column with Heading
  * Slug: purple/product-related-4-column
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, related, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.

--- a/purple/patterns/woocommerce-related-products-collection.php
+++ b/purple/patterns/woocommerce-related-products-collection.php
@@ -2,7 +2,7 @@
 /**
  * Title: Related products collection
  * Slug: purple/related-products-collection
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, related, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a carousel of related products.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Related products collection","categories":["purple"]},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Related products collection","categories":["woo-commerce","purple"]},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":21,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true},"productReference":74},"tagName":"div","displayLayout":{"type":"carousel","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/related","hideControls":["inherit"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":true,"previewMessage":"Actual products will vary depending on the product being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:group {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0;line-height:1"><!-- wp:heading {"fontSize":"x-large"} -->

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -2,7 +2,7 @@
 /**
  * Title: Upsell products collection
  * Slug: purple/upsell-products-collection
- * Categories: purple
+ * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, upsell, collection
  * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a carousel of upsell products.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Upsell products collection","categories":["purple"],"patternName":"purple/upsell-products-collection"},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Upsell products collection","categories":["woo-commerce","purple"],"patternName":"purple/upsell-products-collection"},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":24,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true},"productReference":74},"tagName":"div","displayLayout":{"type":"carousel","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/upsells","hideControls":["inherit","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":true,"previewMessage":"Actual products will vary depending on the product being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:group {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0;line-height:1"><!-- wp:heading {"fontSize":"x-large"} -->


### PR DESCRIPTION
## Summary
- Add `purple` to all insertable patterns that were missing it (about, contact, footer, testimonials, size chart).
- Tag all shop/product patterns with `woo-commerce, purple` for consistent Shop inserter grouping.
- Sync root block `metadata.categories` where it was out of date with the PHP headers.

**Depends on:** #231 (batch 1)

## Category rules applied
- Every insertable pattern includes `purple`.
- Shop/product patterns also include `woo-commerce` (product collections, category grids, size chart, new arrival, hero-with-one-button).
- Secondary category first, then `purple` (e.g. `about, purple`; `woo-commerce, purple`).

## Test plan
- [ ] Pattern inserter: verify affected patterns appear under **Purple** and **Shop** where expected.
- [ ] Confirm about/contact/footer/testimonials patterns still appear under their secondary categories.

Made with [Cursor](https://cursor.com)