### PR TITLE
Purple: pattern header batch 3 — polish

### DIFF
--- a/purple/patterns/about-centered-text.php
+++ b/purple/patterns/about-centered-text.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Centered text","patternName":"purple/about-centered-text","description":"A description section aligned center.","categories":["purple"]},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default has-theme-2-color has-text-color has-link-color" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:paragraph {"style":{"typography":{"textAlign":"center"}},"fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"><?php esc_html_e('Our products are crafted with meticulous attention to quality, using only the finest materials and ingredients. Designed to deliver exceptional performance, each item undergoes rigorous testing to ensure it meets the highest standards.', 'purple');?></p>

--- a/purple/patterns/about-features-2-columns.php
+++ b/purple/patterns/about-features-2-columns.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"categories":["purple"],"name":"Heading, image and list of features","patternName":"purple/about-features-2-columns","description":"A section with a heading, paragraph, a list of features with icons and an image."},"align":"full","className":"alignfull is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"40%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->

--- a/purple/patterns/about-left-aligned-image-right-text.php
+++ b/purple/patterns/about-left-aligned-image-right-text.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"categories":["purple"],"name":"Left-aligned image, text on the right","patternName":"purple/about-left-aligned-image-right-text","description":"An intro section with a heading, paragraph, button and image."},"align":"full","className":"alignfull","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"backgroundColor":"theme-5","layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull has-theme-5-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->

--- a/purple/patterns/about-left-aligned-text-right-image.php
+++ b/purple/patterns/about-left-aligned-text-right-image.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Left-aligned text, image on the right","categories":["purple"],"patternName":"purple/about-left-aligned-text-right-image","description":"A section with an image on the right, description on the left."},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-theme-5-background-color has-background" style="margin-top:0;margin-bottom:0"><!-- wp:columns {"align":"wide","className":"is-style-default","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
 <div class="wp-block-columns alignwide is-style-default"><!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->

--- a/purple/patterns/categories-on-three-columns.php
+++ b/purple/patterns/categories-on-three-columns.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Categories on three columns","patternName":"purple/categories-on-three-columns","description":"A section with three columns of categories with images.","categories":["woo-commerce","purple"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->

--- a/purple/patterns/contact-form-with-address-and-image.php
+++ b/purple/patterns/contact-form-with-address-and-image.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Contact","categories":["about","contact","purple"],"patternName":"purple/contact-form-with-address-and-image"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":""} -->

--- a/purple/patterns/footer-alternative.php
+++ b/purple/patterns/footer-alternative.php
@@ -4,8 +4,8 @@
  * Slug: purple/footer-alternative
  * Categories: footer, purple
  * Keywords: footer, contact, social, links
- * Block Types: core/template-part/footer
  * Description: A three-column store footer with site title and address, contact info, social links, and a bottom row with legal links and copyright.
+ * Block Types: core/template-part/footer
  * Viewport width: 1440
  */
 ?>

--- a/purple/patterns/footer.php
+++ b/purple/patterns/footer.php
@@ -4,8 +4,8 @@
  * Slug: purple/footer
  * Categories: footer, purple
  * Keywords: footer, contact, social, navigation, links
- * Block Types: core/template-part/footer
  * Description: A footer pattern with social links and navigation.
+ * Block Types: core/template-part/footer
  * Viewport width: 1440
  */
 ?>

--- a/purple/patterns/hero-with-text-and-one-button.php
+++ b/purple/patterns/hero-with-text-and-one-button.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Hero with text and two buttons","categories":["woo-commerce","purple"],"patternName":"purple/hero-with-text-and-one-button"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0">
 <!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp","alt":"<?php esc_attr_e('Placeholder image', 'purple');?>","dimRatio":40,"overlayColor":"theme-2","isUserOverlayColor":true,"minHeight":60,"minHeightUnit":"vh","contentPosition":"center center","sizeSlug":"large","align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->

--- a/purple/patterns/hidden-404.php
+++ b/purple/patterns/hidden-404.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Page not found"},"align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull"><!-- wp:spacer {"height":"var:preset|spacing|80"} -->
 <div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/purple/patterns/hidden-blog-heading.php
+++ b/purple/patterns/hidden-blog-heading.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:heading {"level":1,"metadata":{"patternName":"purple/hidden-blog-heading","name":"Hidden blog heading"},"align":"wide"} -->
 <h1 class="wp-block-heading alignwide"><?php esc_html_e( 'Blog', 'purple' ); ?></h1>
 <!-- /wp:heading -->

--- a/purple/patterns/hidden-header-search.php
+++ b/purple/patterns/hidden-header-search.php
@@ -5,4 +5,5 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","buttonPosition":"button-only","buttonUseIcon":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->

--- a/purple/patterns/hidden-no-search-results.php
+++ b/purple/patterns/hidden-no-search-results.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:paragraph {"align":"left","metadata":{"patternName":"purple/no-search-results","name":"No search results"},"style":{"typography":{"textAlign":"left"}}} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'No results were found using that search.', 'Text explaining that there are no results returned from a search', 'purple' ); ?></p>
 <!-- /wp:paragraph -->

--- a/purple/patterns/hidden-page-cart.php
+++ b/purple/patterns/hidden-page-cart.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 	<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","contentSize":"1060px"}} -->
 	<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--40)">

--- a/purple/patterns/hidden-search-products.php
+++ b/purple/patterns/hidden-search-products.php
@@ -5,4 +5,5 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Search products...', 'Product search input placeholder.', 'purple' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","query":{"post_type":"product"},"namespace":"woocommerce/product-search"} /-->

--- a/purple/patterns/hidden-single-product.php
+++ b/purple/patterns/hidden-single-product.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Single Product"},"align":"wide","style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/store-notices /-->
 

--- a/purple/patterns/hidden-woocommerce-product-details.php
+++ b/purple/patterns/hidden-woocommerce-product-details.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 ?>
+
 <!-- wp:woocommerce/product-details -->
 <div class="wp-block-woocommerce-product-details"><!-- wp:woocommerce/accordion-group {"style":{"spacing":{"blockGap":"0"}}} -->
 <div class="wp-block-woocommerce-accordion-group"><!-- wp:woocommerce/accordion-item -->

--- a/purple/patterns/page-about-additional-information.php
+++ b/purple/patterns/page-about-additional-information.php
@@ -4,12 +4,13 @@
  * Slug: purple/page-about-additional-information
  * Categories: purple
  * Keywords: starter
+ * Description: An about page with alternating columns, category collection, and FAQ.
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1440
- * Description: An about page pattern.
  */
 ?>
+
 <!-- wp:pattern {"slug":"purple/about-alternating-columns"} /-->
 <!-- wp:pattern {"slug":"purple/about-category-collection"} /-->
 <!-- wp:pattern {"slug":"purple/about-faq-question-list"} /-->

--- a/purple/patterns/page-about-with-store-information.php
+++ b/purple/patterns/page-about-with-store-information.php
@@ -4,12 +4,13 @@
  * Slug: purple/page-about-with-store-information
  * Categories: purple
  * Keywords: starter
+ * Description: An about page with store features, intro sections, and a features list with image.
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1440
- * Description: An about page pattern.
  */
 ?>
+
 <!-- wp:pattern {"slug":"purple/store-features-three-columns-alternative"} /-->
 <!-- wp:pattern {"slug":"purple/about-left-aligned-text-right-image"} /-->
 <!-- wp:pattern {"slug":"purple/about-centered-text"} /-->

--- a/purple/patterns/page-coming-soon.php
+++ b/purple/patterns/page-coming-soon.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Title: Coming Soon
+ * Title: Coming soon
  * Slug: purple/coming-soon
  * Categories: purple
  * Keywords: coming soon, starter, landing
+ * Description: A coming soon page pattern.
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1440
- * Description: A coming soon page pattern.
  */
 ?>
 

--- a/purple/patterns/page-home-alternative-2.php
+++ b/purple/patterns/page-home-alternative-2.php
@@ -4,12 +4,13 @@
  * Slug: purple/page-home-alternative-2
  * Categories: purple
  * Keywords: starter
+ * Description: A shop homepage with category highlights, new arrival feature, and store features.
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1440
- * Description: A shop homepage pattern.
  */
 ?>
+
 <!-- wp:pattern {"slug":"purple/two-columns-full-width-categories"} /-->
 <!-- wp:pattern {"slug":"purple/new-arrival-product"} /-->
 <!-- wp:pattern {"slug":"purple/woocommerce-featured-products"} /-->

--- a/purple/patterns/page-home-alternative.php
+++ b/purple/patterns/page-home-alternative.php
@@ -4,12 +4,13 @@
  * Slug: purple/page-home-alternative
  * Categories: purple
  * Keywords: starter
+ * Description: A shop homepage with hero, best sellers, testimonials, featured products, and newsletter signup.
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1440
- * Description: A shop homepage pattern.
  */
 ?>
+
 <!-- wp:pattern {"slug":"purple/hero-with-text-and-one-button"} /-->
 <!-- wp:pattern {"slug":"purple/woocommerce-best-sellers-3-columns"} /-->
 <!-- wp:pattern {"slug":"purple/testimonials-in-two-columns"} /-->

--- a/purple/patterns/page-home.php
+++ b/purple/patterns/page-home.php
@@ -6,6 +6,7 @@
  * Template Types: front-page, index, home
  */
 ?>
+
 <!-- wp:pattern {"slug":"purple/hero-with-text-and-two-buttons"} /-->
 <!-- wp:pattern {"slug":"purple/woocommerce-new-arrivals"} /-->
 <!-- wp:pattern {"slug":"purple/two-columns-full-width-categories"} /-->

--- a/purple/patterns/posts-three-columns-center-aligned-heading.php
+++ b/purple/patterns/posts-three-columns-center-aligned-heading.php
@@ -4,11 +4,12 @@
  * Slug: purple/posts-three-columns-center-aligned-heading
  * Categories: purple
  * Keywords: posts, blog, query, columns, grid
- * Description: A list of posts, 3 columns, with featured image, post date and title.
+ * Description: A list of posts in 3 columns with a center-aligned section heading.
  * Block Types: core/query
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"List of posts with center aligned heading","categories":["purple"],"patternName":"purple/posts-three-columns-center-aligned-heading"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08rem","textAlign":"center"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"small"} -->
 <p class="has-text-align-center has-theme-2-color has-text-color has-link-color has-small-font-size" style="letter-spacing:0.08rem;text-transform:uppercase"><?php esc_html_e( 'Journal', 'purple' ); ?></p>

--- a/purple/patterns/posts-three-columns-left-aligned-heading.php
+++ b/purple/patterns/posts-three-columns-left-aligned-heading.php
@@ -4,11 +4,12 @@
  * Slug: purple/posts-three-columns-left-aligned-heading
  * Categories: purple
  * Keywords: posts, blog, query, columns, grid
- * Description: A list of posts, 3 columns, with featured image, post date and title.
+ * Description: A list of posts in 3 columns with a left-aligned section heading.
  * Block Types: core/query
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"List of posts with left aligned heading","categories":["purple"],"patternName":"purple/posts-three-columns-left-aligned-heading"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"bottom":"0","top":"0"}},"typography":{"textAlign":"left"}}} -->

--- a/purple/patterns/posts-three-columns.php
+++ b/purple/patterns/posts-three-columns.php
@@ -4,13 +4,13 @@
  * Slug: purple/posts-three-columns
  * Categories: purple
  * Keywords: posts, blog, query, columns, grid
- * Description: A list of posts, 3 columns, with featured image, post date and title.
+ * Description: A list of posts in 3 columns with featured image, date, and title.
  * Block Types: core/query
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"List of posts in three columns","categories":["purple"],"description":"A list of posts, 3 columns, with featured image, post date and title.","patternName":"purple/posts-three-columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"0","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"List of posts in three columns","categories":["purple"],"description":"A list of posts in 3 columns with featured image, date, and title.","patternName":"purple/posts-three-columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"0","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:0;padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->

--- a/purple/patterns/reviews-heading-left.php
+++ b/purple/patterns/reviews-heading-left.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Review: Heading on left, two columns of reviews on right
+ * Title: Reviews: heading on left, two columns of reviews on right
  * Slug: purple/reviews-heading-left
  * Categories: testimonials, purple
  * Keywords: reviews, testimonials, ratings, stars, columns
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Reviews","categories":["testimonials","purple"],"patternName":"purple/reviews-heading-left"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"metadata":{"name":"Items"},"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->

--- a/purple/patterns/reviews-three-columns.php
+++ b/purple/patterns/reviews-three-columns.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Reviews","categories":["testimonials","purple"],"patternName":"purple/reviews-three-columns"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"wide","style":{"typography":{"textAlign":"left"}}} -->
 <h2 class="wp-block-heading has-text-align-left alignwide"><?php esc_html_e( 'Reviews', 'purple' ); ?></h2>

--- a/purple/patterns/size-chart.php
+++ b/purple/patterns/size-chart.php
@@ -9,6 +9,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:paragraph  -->
 <p><?php esc_html_e('These size charts are a guide to help you find the right size for you. As many pieces are designed in a unique way, we suggest you also refer to the specific garment lengths and measurements provided in the product descriptions.', 'purple');?></p>

--- a/purple/patterns/social-media-call-to-action-with-hero-image.php
+++ b/purple/patterns/social-media-call-to-action-with-hero-image.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Social media call to action with hero image"},"align":"full","className":"is-style-section-1","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-section-1"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp","alt":"<?php esc_attr_e( 'Placeholder image', 'purple' ); ?>","dimRatio":40,"overlayColor":"theme-2","isUserOverlayColor":true,"minHeight":60,"minHeightUnit":"vh","sizeSlug":"large","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);min-height:60vh"><img class="wp-block-cover__image-background size-large" alt="<?php esc_attr_e( 'Placeholder image', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-40 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center"} -->

--- a/purple/patterns/stockists.php
+++ b/purple/patterns/stockists.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Stockists","categories":["purple"],"patternName":"purple/stockists"},"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|50","right":"var:preset|spacing|50","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-group alignwide" style="padding-right:0;padding-left:0"><!-- wp:heading {"level":1,"style":{"typography":{"textAlign":"left"}}} -->

--- a/purple/patterns/store-features-four-columns-alternative.php
+++ b/purple/patterns/store-features-four-columns-alternative.php
@@ -4,11 +4,12 @@
  * Slug: purple/store-features-four-columns-alternative
  * Categories: purple
  * Keywords: about, text, media, columns
- * Description: A four-column section with store featured services.
+ * Description: A four-column store features section with an alternative layout.
  * Viewport width: 1440
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Four columns of store features with icons","categories":["purple"],"patternName":"purple/store-features-four-columns-alternative","description":"A four-column section with store featured services."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+
+<!-- wp:group {"metadata":{"name":"Four columns of store features with icons","categories":["purple"],"patternName":"purple/store-features-four-columns-alternative","description":"A four-column store features section with an alternative layout."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"isStackedOnMobile":false,"align":"wide","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
 <div class="wp-block-columns alignwide is-not-stacked-on-mobile"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0","bottom":"0"}}}} -->
 <div class="wp-block-column" style="padding-top:0;padding-bottom:0"><!-- wp:columns {"metadata":{"categories":["text","about"],"patternName":"purple/store-features-four-columns-alternative"},"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":{"top":"var:preset|spacing|60","left":"0"}}}} -->

--- a/purple/patterns/store-features-three-columns-alternative.php
+++ b/purple/patterns/store-features-three-columns-alternative.php
@@ -4,11 +4,12 @@
  * Slug: purple/store-features-three-columns-alternative
  * Categories: purple
  * Keywords: about, text, media, columns
- * Description: A three-column section with store featured services.
+ * Description: A three-column store features section with an alternative icon layout.
  * Viewport width: 1440
  */
 ?>
-<!-- wp:group {"metadata":{"name":"Three columns of store features with icons alternative","categories":["purple"],"patternName":"purple/store-features-three-columns-alternative","description":"A three-column section with store featured services."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+
+<!-- wp:group {"metadata":{"name":"Three columns of store features with icons alternative","categories":["purple"],"patternName":"purple/store-features-three-columns-alternative","description":"A three-column store features section with an alternative icon layout."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:columns {"metadata":{"categories":["text","about"],"patternName":"purple/store-features-four-columns"},"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"0"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->

--- a/purple/patterns/store-features-three-columns.php
+++ b/purple/patterns/store-features-three-columns.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Three columns of store features with icons","categories":["purple"],"patternName":"purple/store-features-three-columns","description":"A three-column section with store featured services."},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:columns {"metadata":{"categories":["text","about"],"patternName":"purple/store-features-four-columns"},"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"0"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->

--- a/purple/patterns/store-features-two-columns.php
+++ b/purple/patterns/store-features-two-columns.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Small store features row with icons","categories":["purple"],"patternName":"purple/store-features-two-columns"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-theme-5-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"metadata":{"categories":["text","about"]},"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->

--- a/purple/patterns/two-columns-highlights-sections.php
+++ b/purple/patterns/two-columns-highlights-sections.php
@@ -8,6 +8,7 @@
  * Viewport width: 1440
  */
 ?>
+
 <!-- wp:group {"metadata":{"name":"Two columns highlights sections","patternName":"purple/two-columns-highlights-sections","description":"A section with 2 columns of highlights","categories":["purple"]},"align":"full","className":"is-style-section-1","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-section-1" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->

--- a/purple/patterns/woocommerce-best-sellers-3-columns.php
+++ b/purple/patterns/woocommerce-best-sellers-3-columns.php
@@ -4,13 +4,13 @@
  * Slug: purple/woocommerce-best-sellers-3-columns
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, best sellers, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 3 column product grid.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"patternName":"purple/woocommerce-best-sellers-3-columns","name":"Best Sellers Collection","description":"A section with a heading and a 3 column product grid."},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"patternName":"purple/woocommerce-best-sellers-3-columns","name":"Best sellers collection, 3 columns","description":"A section with a heading and a 3 column product grid."},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:heading -->

--- a/purple/patterns/woocommerce-best-sellers.php
+++ b/purple/patterns/woocommerce-best-sellers.php
@@ -4,13 +4,13 @@
  * Slug: purple/woocommerce-best-sellers
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, best sellers, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"name":"Best Sellers Collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-best-sellers"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"name":"Best sellers collection, 4 columns","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-best-sellers"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":56,"query":{"perPage":4,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"popularity","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/best-sellers","hideControls":["inherit","order","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"style":{"typography":{"textAlign":"center","lineHeight":"1.21"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"x-large"} --><h2 class="wp-block-heading has-text-align-center has-x-large-font-size" style="margin-top:0;margin-bottom:0;line-height:1.21"><?php esc_html_e('Best sellers', 'purple');?></h2>
 <!-- /wp:heading -->

--- a/purple/patterns/woocommerce-featured-products.php
+++ b/purple/patterns/woocommerce-featured-products.php
@@ -4,8 +4,8 @@
  * Slug: purple/woocommerce-featured-products
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, featured, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>

--- a/purple/patterns/woocommerce-new-arrivals.php
+++ b/purple/patterns/woocommerce-new-arrivals.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Title: New Arrivals Collection
+ * Title: New arrivals collection
  * Slug: purple/woocommerce-new-arrivals
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, new arrivals, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"name":"New Arrivals Collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-new-arrivals"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"categories":["woo-commerce","purple"],"name":"New arrivals collection","description":"A section with a heading and a 4 column product grid.","patternName":"purple/woocommerce-new-arrivals"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":5,"query":{"perPage":4,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"timeFrame":{"operator":"not-in","value":"-7 days"},"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/new-arrivals","hideControls":["inherit","order","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"style":{"typography":{"textAlign":"center","lineHeight":"1.21"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"x-large"} --><h2 class="wp-block-heading has-text-align-center has-x-large-font-size" style="margin-top:0;margin-bottom:0;line-height:1.21"><?php esc_html_e('New arrivals', 'purple');?></h2>
 <!-- /wp:heading -->

--- a/purple/patterns/woocommerce-product-related-4-column.php
+++ b/purple/patterns/woocommerce-product-related-4-column.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Title: Products, 4 column with Heading
+ * Title: Products, 4 columns with heading
  * Slug: purple/product-related-4-column
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, related, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a 4 column product grid.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Products, 4 column with Heading"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Products, 4 columns with heading"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":10,"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":true,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill","fixedWidth":"20px"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"align":"wide","style":{"typography":{"textAlign":"center"}},"fontSize":"x-large"} -->
 <h2 class="wp-block-heading has-text-align-center alignwide has-x-large-font-size"><?php esc_html_e( 'You might like', 'purple' ); ?></h2>

--- a/purple/patterns/woocommerce-related-products-collection.php
+++ b/purple/patterns/woocommerce-related-products-collection.php
@@ -4,8 +4,8 @@
  * Slug: purple/related-products-collection
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, related, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a carousel of related products.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -4,8 +4,8 @@
  * Slug: purple/upsell-products-collection
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, upsell, collection
- * Block Types: woocommerce/product-collection
  * Description: A section with a heading and a carousel of upsell products.
+ * Block Types: woocommerce/product-collection
  * Viewport width: 1440
  */
 ?>


### PR DESCRIPTION
## Summary
- Normalize header field order across all 61 patterns (`Description` before `Block Types`/`Viewport width`).
- Sentence-case inconsistent titles (`Coming soon`, `New arrivals collection`, etc.).
- Differentiate duplicate inserter descriptions for homepage alternatives, about page starters, posts lists, and store-feature variants.
- Sync matching block `metadata` names/descriptions where they mirrored outdated header text.

## Test plan
- [ ] Pattern inserter: spot-check renamed titles and updated descriptions are distinct and readable.
- [ ] Confirm no pattern registration issues (headers still parse correctly).

Made with [Cursor](https://cursor.com)