### PR TITLE
Purple: align WooCommerce pattern slugs with filenames

### DIFF
--- a/purple/patterns/hidden-page-cart.php
+++ b/purple/patterns/hidden-page-cart.php
@@ -122,5 +122,5 @@
 	</main>
 	<!-- /wp:group -->
 
-	<!-- wp:pattern {"slug":"purple/upsell-products-collection"} /-->
+	<!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
 <!-- /wp:woocommerce/page-content-wrapper -->

--- a/purple/patterns/hidden-single-product.php
+++ b/purple/patterns/hidden-single-product.php
@@ -78,9 +78,9 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:pattern {"slug":"purple/upsell-products-collection"} /-->
+<!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
 
-<!-- wp:pattern {"slug":"purple/related-products-collection"} /-->
+<!-- wp:pattern {"slug":"purple/woocommerce-related-products-collection"} /-->
 
 <!-- wp:pattern {"slug":"purple/about-left-aligned-product-right-text"} /-->
 

--- a/purple/patterns/woocommerce-product-related-4-column.php
+++ b/purple/patterns/woocommerce-product-related-4-column.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: Products, 4 columns with heading
- * Slug: purple/product-related-4-column
+ * Slug: purple/woocommerce-product-related-4-column
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, related, collection
  * Description: A section with a heading and a 4 column product grid.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Products, 4 columns with heading"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Products, 4 columns with heading","patternName":"purple/woocommerce-product-related-4-column"},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"blockGap":"0","padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":10,"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":true,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill","fixedWidth":"20px"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:heading {"align":"wide","style":{"typography":{"textAlign":"center"}},"fontSize":"x-large"} -->
 <h2 class="wp-block-heading has-text-align-center alignwide has-x-large-font-size"><?php esc_html_e( 'You might like', 'purple' ); ?></h2>

--- a/purple/patterns/woocommerce-related-products-collection.php
+++ b/purple/patterns/woocommerce-related-products-collection.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: Related products collection
- * Slug: purple/related-products-collection
+ * Slug: purple/woocommerce-related-products-collection
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, related, collection
  * Description: A section with a heading and a carousel of related products.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Related products collection","categories":["woo-commerce","purple"]},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Related products collection","categories":["woo-commerce","purple"],"patternName":"purple/woocommerce-related-products-collection"},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":21,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true},"productReference":74},"tagName":"div","displayLayout":{"type":"carousel","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/related","hideControls":["inherit"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":true,"previewMessage":"Actual products will vary depending on the product being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:group {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0;line-height:1"><!-- wp:heading {"fontSize":"x-large"} -->

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: Upsell products collection
- * Slug: purple/upsell-products-collection
+ * Slug: purple/woocommerce-upsell-products-collection
  * Categories: woo-commerce, purple
  * Keywords: woo-commerce, products, upsell, collection
  * Description: A section with a heading and a carousel of upsell products.
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Upsell products collection","categories":["woo-commerce","purple"],"patternName":"purple/upsell-products-collection"},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Upsell products collection","categories":["woo-commerce","purple"],"patternName":"purple/woocommerce-upsell-products-collection"},"align":"full","className":"is-style-default","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-collection {"queryId":24,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true},"productReference":74},"tagName":"div","displayLayout":{"type":"carousel","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/upsells","hideControls":["inherit","filterable"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":true,"previewMessage":"Actual products will vary depending on the product being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:group {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0;line-height:1"><!-- wp:heading {"fontSize":"x-large"} -->

--- a/purple/templates/404.html
+++ b/purple/templates/404.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"layout":{"type":"constrained","contentSize":"400px","wideSize":"720px"}} -->
 <main class="wp-block-group">
     <!-- wp:pattern {"slug":"purple/hidden-404"} /-->
-    <!-- wp:pattern {"slug":"purple/upsell-products-collection"} /-->
+    <!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- Rename three pattern slugs to match their `woocommerce-*.php` filenames:
  - `purple/upsell-products-collection` → `purple/woocommerce-upsell-products-collection`
  - `purple/related-products-collection` → `purple/woocommerce-related-products-collection`
  - `purple/product-related-4-column` → `purple/woocommerce-product-related-4-column`
- Update references in `hidden-single-product`, `hidden-page-cart`, and `404.html`.
- Add missing `patternName` metadata on related/product-related patterns.

All seven `woocommerce-*` pattern files now use slugs consistent with their filenames.

## Test plan
- [ ] Single product page: upsell and related product sections render.
- [ ] Cart page: upsell section renders.
- [ ] 404 template: upsell section renders.
- [ ] Pattern inserter: three renamed patterns still appear under Purple / Shop.

Made with [Cursor](https://cursor.com)