### PR TITLE
Purple: pattern audit issues 11–12

### DIFF
--- a/purple/patterns/hidden-blog-heading.php
+++ b/purple/patterns/hidden-blog-heading.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Title: Hidden blog heading
+ * Title: Blog heading
  * Slug: purple/hidden-blog-heading
  * Inserter: no
  */
 ?>
 
-<!-- wp:heading {"level":1,"metadata":{"patternName":"purple/hidden-blog-heading","name":"Hidden blog heading"},"align":"wide"} -->
+<!-- wp:heading {"level":1,"metadata":{"patternName":"purple/hidden-blog-heading","name":"Blog heading"},"align":"wide"} -->
 <h1 class="wp-block-heading alignwide"><?php esc_html_e( 'Blog', 'purple' ); ?></h1>
 <!-- /wp:heading -->

--- a/purple/patterns/hidden-no-search-results.php
+++ b/purple/patterns/hidden-no-search-results.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Title: No search results
- * Slug: purple/no-search-results
+ * Slug: purple/hidden-no-search-results
  * Inserter: no
  */
 ?>
 
-<!-- wp:paragraph {"align":"left","metadata":{"patternName":"purple/no-search-results","name":"No search results"},"style":{"typography":{"textAlign":"left"}}} -->
+<!-- wp:paragraph {"align":"left","metadata":{"patternName":"purple/hidden-no-search-results","name":"No search results"},"style":{"typography":{"textAlign":"left"}}} -->
 <p class="has-text-align-left"><?php echo esc_html_x( 'No results were found using that search.', 'Text explaining that there are no results returned from a search', 'purple' ); ?></p>
 <!-- /wp:paragraph -->

--- a/purple/patterns/hidden-product-grid-with-filters.php
+++ b/purple/patterns/hidden-product-grid-with-filters.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Title: Hidden product grid with filters
+ * Title: Product grid with filters
  * Slug: purple/hidden-product-grid-with-filters
  * Inserter: no
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Product grids with filters","patternName":"purple/hidden-product-grid-with-filters"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Product grid with filters","patternName":"purple/hidden-product-grid-with-filters"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:0"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"22%"} -->
 <div class="wp-block-column" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->

--- a/purple/patterns/posts-three-columns.php
+++ b/purple/patterns/posts-three-columns.php
@@ -22,7 +22,7 @@
 <!-- /wp:post-template -->
 
 <!-- wp:query-no-results -->
-<!-- wp:pattern {"slug":"purple/no-search-results"} /-->
+<!-- wp:pattern {"slug":"purple/hidden-no-search-results"} /-->
 <!-- /wp:query-no-results -->
 
 <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->


### PR DESCRIPTION
## Summary
- **Issue 11:** Align `hidden-no-search-results` slug to `purple/hidden-no-search-results` (was `purple/no-search-results`). Normalize hidden pattern titles by removing inconsistent "Hidden" prefixes (`blog heading`, `product grid with filters`).
- **Issue 12:** Already fixed in #231 (`page-home-alternative-2` slug). Verified all `purple/*` pattern references in the theme resolve to registered slugs.

## Hidden pattern rules (now consistent)
- Filename `hidden-*.php` → slug `purple/hidden-*`
- Titles are descriptive sentence case without a redundant "Hidden" prefix (`Inserter: no` already excludes them from the inserter)

## Test plan
- [ ] Blog index: heading pattern still renders.
- [ ] Product archive/search: grid-with-filters pattern still renders.
- [ ] Posts three columns: no-results fallback still renders when query is empty.

Made with [Cursor](https://cursor.com)