### PR TITLE
Purple: fix spacingSizes fluid formula

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -72,7 +72,6 @@
 			]
 		},
 		"custom": {
-			"spacing-increment": "1",
 			"spacing-unit": "10"
 		},
 		"layout": {
@@ -87,37 +86,37 @@
 			"spacingSizes": [
 				{
 					"name": "2X-Small",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 1 * 1px), calc(var(--wp--custom--spacing-increment) * 2.42 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 1 * 1px), calc(var(--wp--custom--spacing-unit) * 1 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "20"
 				},
 				{
 					"name": "X-Small",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 2 * 1px), calc(var(--wp--custom--spacing-increment) * 3.38 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 2 * 1px), calc(var(--wp--custom--spacing-unit) * 2 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "30"
 				},
 				{
 					"name": "Small",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 3 * 1px), calc(var(--wp--custom--spacing-increment) * 4.35 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 3 * 1px), calc(var(--wp--custom--spacing-unit) * 3 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "40"
 				},
 				{
 					"name": "Regular",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 5 * 1px), calc(var(--wp--custom--spacing-increment) * 4.83 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 5 * 1px), calc(var(--wp--custom--spacing-unit) * 5 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "50"
 				},
 				{
 					"name": "Large",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 7 * 1px), calc(var(--wp--custom--spacing-increment) * 7.25 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 7 * 1px), calc(var(--wp--custom--spacing-unit) * 7 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "60"
 				},
 				{
 					"name": "Extra Large",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 9 * 1px), calc(var(--wp--custom--spacing-increment) * 12.08 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 9 * 1px), calc(var(--wp--custom--spacing-unit) * 9 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "70"
 				},
 				{
 					"name": "2X Large",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 14 * 1px), calc(var(--wp--custom--spacing-increment) * 16.91 * 1vw))",
+                    "size": "min(calc(var(--wp--custom--spacing-unit) * 14 * 1px), calc(var(--wp--custom--spacing-unit) * 14 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "80"
 				}
 			]


### PR DESCRIPTION
## Summary
- Replace arbitrary per-step `vw` coefficients in `spacingSizes` with a single formula tied to `layout.wideSize` via `--wp--style--global--wide-size`.
- Each step now uses `min(fixed px, fixed px * 100vw / wide-size)` so spacing caps at design values at 1340px and scales proportionally below it.
- Remove unused `spacing-increment` custom property.

## Test plan
- [ ] At 1340px+ viewport, spacing presets match previous fixed values (10, 20, 30, 50, 70, 90, 140px).
- [ ] Below 1340px, spacing scales down smoothly (e.g. half at 670px).
- [ ] Spot-check patterns/templates that rely on spacing-50/60/70 on mobile.


Made with [Cursor](https://cursor.com)