### PR TITLE
Purple: fix single-product WooCommerce wrapper spacing

### DIFF
--- a/purple/patterns/hidden-single-product.php
+++ b/purple/patterns/hidden-single-product.php
@@ -32,8 +32,8 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:post-title {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"x-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"},"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--10)"><!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"fontSize":"large","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"0"}}}} /-->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)"><!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"fontSize":"large","style":{"typography":{"lineHeight":"1"},"spacing":{"padding":{"top":"0"}}}} /-->
 
 <!-- wp:woocommerce/product-sale-badge /--></div>
 <!-- /wp:group -->

--- a/purple/templates/single-product.html
+++ b/purple/templates/single-product.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--70)">
+<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"className":"woocommerce product","__wooCommerceIsFirstBlock":true,"__wooCommerceIsLastBlock":true,"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group woocommerce product" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--70)">
 	
     <!-- wp:pattern {"slug":"purple/hidden-single-product"} /-->
 


### PR DESCRIPTION
## Summary
- Add `woocommerce product` classes and `__wooCommerceIsFirstBlock` / `__wooCommerceIsLastBlock` attrs to the `<main>` landmark in `single-product.html`.
- Prevents WooCommerce's compatibility layer from injecting an extra wrapping `div` around `<main>`, which was picking up unwanted top spacing from block layout.

## Test plan
- [ ] Single product page — no extra gap between header and product content.
- [ ] Inspect DOM — `<main class="wp-block-group woocommerce product">` with no parent `div.woocommerce.product`.
- [ ] Product gallery, add-to-cart, tabs, and related products still render correctly.
- [ ] If testing on a site with a customized Single Product template, clear customizations so the theme file change applies.


Made with [Cursor](https://cursor.com)