### PR TITLE
Align Purple homepage templates with WordPress hierarchy

### DIFF
--- a/purple/patterns/page-home.php
+++ b/purple/patterns/page-home.php
@@ -3,7 +3,7 @@
  * Title: Shop homepage
  * Slug: purple/home
  * Inserter: no
- * Template Types: front-page, index, home
+ * Template Types: front-page
  */
 ?>
 

--- a/purple/patterns/page-storefront-alternative-2.php
+++ b/purple/patterns/page-storefront-alternative-2.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Shop homepage alternative 2
- * Slug: purple/page-home-alternative-2
+ * Title: Storefront alternative 2
+ * Slug: purple/page-storefront-alternative-2
  * Categories: purple
  * Keywords: starter
  * Description: A shop homepage with category highlights, new arrival feature, and store features.

--- a/purple/patterns/page-storefront-alternative.php
+++ b/purple/patterns/page-storefront-alternative.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Shop homepage alternative
- * Slug: purple/page-home-alternative
+ * Title: Storefront alternative
+ * Slug: purple/page-storefront-alternative
  * Categories: purple
  * Keywords: starter
  * Description: A shop homepage with hero, best sellers, testimonials, featured products, and newsletter signup.

--- a/purple/patterns/page-storefront.php
+++ b/purple/patterns/page-storefront.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Shop homepage
- * Slug: purple/home
+ * Title: Storefront
+ * Slug: purple/storefront
  * Inserter: no
  * Template Types: front-page
  */

--- a/purple/templates/front-page.html
+++ b/purple/templates/front-page.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","metadata":{"name":"Storefront"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
 
-<!-- wp:pattern {"slug":"purple/home"} /-->
+<!-- wp:pattern {"slug":"purple/storefront"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/front-page.html
+++ b/purple/templates/front-page.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","metadata":{"name":"Storefront"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:0;margin-bottom:0">
+
+<!-- wp:pattern {"slug":"purple/home"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/purple/templates/home.html
+++ b/purple/templates/home.html
@@ -1,10 +1,9 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0">
-	
-<!-- wp:pattern {"slug":"purple/home"} /-->
-
+<!-- wp:group {"tagName":"main","metadata":{"name":"Blog"},"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50","top":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--90);padding-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:pattern {"slug":"purple/hidden-blog-heading"} /-->
+	<!-- wp:pattern {"slug":"purple/posts-three-columns"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- Add `front-page.html` with the storefront pattern (`purple/home`) for the site front page on fresh installs.
- Move the blog posts layout into `home.html` (heading + `posts-three-columns`) so Reading → Posts page works correctly.
- Leave `index.html` unchanged as the blog fallback.
- Limit `purple/home` pattern template types to `front-page` only.

## Test plan
- [ ] Fresh install / Reading → Latest posts: `/` shows storefront demo via `front-page.html`
- [ ] Reading → Static homepage + Posts page: Posts page shows blog grid via `home.html`
- [ ] `/shop/` still uses `archive-product.html`
- [ ] Site Editor lists templates as Storefront / Blog / Index with expected content


Made with [Cursor](https://cursor.com)