### PR TITLE
Normalize Purple theme indentation to tabs

### DIFF
--- a/purple/parts/header-alternative.html
+++ b/purple/parts/header-alternative.html
@@ -1,37 +1,37 @@
 <!-- wp:group {"metadata":{"name":"Alternative header"},"style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"
-    style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
-    <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-    <div class="wp-block-group alignfull">
-        <!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"align":"wide"} -->
-        <div class="wp-block-columns alignwide are-vertically-aligned-center is-not-stacked-on-mobile">
-            <!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
-            <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
-                <!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /-->
-            </div>
-            <!-- /wp:column -->
+	style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
+	<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull">
+		<!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"align":"wide"} -->
+		<div class="wp-block-columns alignwide are-vertically-aligned-center is-not-stacked-on-mobile">
+			<!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
+				<!-- wp:navigation {"metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"]}} /-->
+			</div>
+			<!-- /wp:column -->
 
-            <!-- wp:column {"verticalAlignment":"center","width":"30%"} -->
-            <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%">
-                <!-- wp:site-title {"style":{"typography":{"textAlign":"center"}}} /--></div>
-            <!-- /wp:column -->
+			<!-- wp:column {"verticalAlignment":"center","width":"30%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%">
+				<!-- wp:site-title {"style":{"typography":{"textAlign":"center"}}} /--></div>
+			<!-- /wp:column -->
 
-            <!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
-            <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
-                <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-                <div class="wp-block-group">
-                    <!-- wp:pattern {"slug":"purple/hidden-header-search"} /-->
+			<!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+				<div class="wp-block-group">
+					<!-- wp:pattern {"slug":"purple/hidden-header-search"} /-->
 
-                    <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
+					<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
 
-                    <!-- wp:woocommerce/mini-cart /-->
-                </div>
-                <!-- /wp:group -->
-            </div>
-            <!-- /wp:column -->
-        </div>
-        <!-- /wp:columns -->
-    </div>
-    <!-- /wp:group -->
+					<!-- wp:woocommerce/mini-cart /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/purple/parts/header.html
+++ b/purple/parts/header.html
@@ -1,30 +1,30 @@
 <!-- wp:group {"metadata":{"name":"Default header"},"style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"
-    style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
-    <!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-    <div class="wp-block-group alignwide">
-        <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-        <div class="wp-block-group"><!-- wp:site-title /-->
+	style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
+	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group"><!-- wp:site-title /-->
 
-            <!-- wp:navigation {"overlayMenu":"never","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
-        </div>
-        <!-- /wp:group -->
+			<!-- wp:navigation {"overlayMenu":"never","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
+		</div>
+		<!-- /wp:group -->
 
-        <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-        <div class="wp-block-group">
-            <!-- wp:pattern {"slug":"purple/hidden-header-search"} /-->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+		<div class="wp-block-group">
+			<!-- wp:pattern {"slug":"purple/hidden-header-search"} /-->
 
-            <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
+			<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"line","iconClass":"wc-block-customer-account__account-icon"} /-->
 
-            <!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-            <div class="wp-block-group"><!-- wp:woocommerce/mini-cart /-->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group"><!-- wp:woocommerce/mini-cart /-->
 
-                <!-- wp:navigation {"overlayMenu":"always","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"desktop":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"large","layout":{"type":"flex","flexWrap":"wrap"}} /-->
-            </div>
-            <!-- /wp:group -->
-        </div>
-        <!-- /wp:group -->
-    </div>
-    <!-- /wp:group -->
+				<!-- wp:navigation {"overlayMenu":"always","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"desktop":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"large","layout":{"type":"flex","flexWrap":"wrap"}} /-->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/purple/style.css
+++ b/purple/style.css
@@ -16,14 +16,14 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 
 /* Utility class for underlined links. */
 .underline-link a {
-    text-decoration: underline;
+	text-decoration: underline;
 } 
 
 /* Add a transition state for buttons. */
 .wp-element-button {
-    transition: border, background-color, color, box-shadow, opacity, filter;
-    transition-duration: 0.15s;
-    transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+	transition: border, background-color, color, box-shadow, opacity, filter;
+	transition-duration: 0.15s;
+	transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 /* Styles for WooCommerce blocks that can't be styled via the editor yet. */
@@ -33,40 +33,40 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 .wc-block-components-checkout-order-summary__title,
 .wc-block-components-totals-coupon,
 .wc-block-components-totals-item {
-    color: var(--wp--preset--color--theme-2);
+	color: var(--wp--preset--color--theme-2);
 }
 
 .wp-block-woocommerce-product-gallery-is-layout-flex {
-    gap: var(--wp--preset--spacing--50);
+	gap: var(--wp--preset--spacing--50);
 }
 
 /* https://github.com/woocommerce/woocommerce/issues/59391 */
 .woocommerce-account .entry-content > .woocommerce {
-    padding-top: var(--wp--preset--spacing--70);
-    padding-bottom: var(--wp--preset--spacing--90);
+	padding-top: var(--wp--preset--spacing--70);
+	padding-bottom: var(--wp--preset--spacing--90);
 }
 
 /* WOOPRD-1561: My Account address styles. */
 .woocommerce-account .addresses .title .edit {
-    float: none;
+	float: none;
 }
 
 .woocommerce-account .addresses address {
-    font-style: normal;
+	font-style: normal;
 }
 
 .wp-block-product-specifications-item__value p {
-    margin: 0
+	margin: 0
 }
 
 /* Checkbox alignment for reviews form */
 .wp-block-woocommerce-product-review-form .comment-form-cookies-consent {
-    align-items: flex-start;
+	align-items: flex-start;
 }
 
 .wc-block-components-quantity-selector {
-    border-color: var(--wp--preset--color--theme-6);
-    border-radius: 0;
+	border-color: var(--wp--preset--color--theme-6);
+	border-radius: 0;
 }
 
 /* Catalog sort order select — CSS customizable select (base-select).
@@ -74,191 +74,191 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
  * Closed/open styles from Figma Dropdown/Default (1:6531) and Dropdown/Open Links (37:1153).
  * Strip native chrome with appearance: none first; opt into base-select for the picker. */
 .woocommerce.wc-block-catalog-sorting {
-    font-size: var(--wp--preset--font-size--medium) !important;
+	font-size: var(--wp--preset--font-size--medium) !important;
 }
 
 .woocommerce.wc-block-catalog-sorting select.orderby {
-    -webkit-appearance: none;
-    appearance: none;
-    background-color: var(--wp--preset--color--theme-1);
-    background-image: url('data:image/svg+xml;utf8,<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="%23111111"></path></svg>');
-    background-position: right center;
-    background-repeat: no-repeat;
-    background-size: 1.5em;
-    border: none;
-    border-radius: 0;
-    color: var(--wp--preset--color--theme-2);
-    cursor: pointer;
-    font-family: inherit;
-    font-size: var(--wp--preset--font-size--medium) !important;
-    font-weight: inherit;
-    line-height: 1.5625;
-    outline: none;
-    padding-block: 0;
-    padding-inline: 0 calc(1.5em + 10px);
-    vertical-align: middle;
+	-webkit-appearance: none;
+	appearance: none;
+	background-color: var(--wp--preset--color--theme-1);
+	background-image: url('data:image/svg+xml;utf8,<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="%23111111"></path></svg>');
+	background-position: right center;
+	background-repeat: no-repeat;
+	background-size: 1.5em;
+	border: none;
+	border-radius: 0;
+	color: var(--wp--preset--color--theme-2);
+	cursor: pointer;
+	font-family: inherit;
+	font-size: var(--wp--preset--font-size--medium) !important;
+	font-weight: inherit;
+	line-height: 1.5625;
+	outline: none;
+	padding-block: 0;
+	padding-inline: 0 calc(1.5em + 10px);
+	vertical-align: middle;
 }
 
 @supports (appearance: base-select) {
-    .woocommerce.wc-block-catalog-sorting select.orderby,
-    .woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {
-        appearance: base-select;
-        background-color: var(--wp--preset--color--theme-1);
-        border: none;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby,
+	.woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {
+		appearance: base-select;
+		background-color: var(--wp--preset--color--theme-1);
+		border: none;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby {
-        align-items: center;
-        background-image: none;
-        box-shadow: none;
-        display: inline-flex;
-        flex-direction: row;
-        gap: 10px;
-        outline: none;
-        padding: 0;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby {
+		align-items: center;
+		background-image: none;
+		box-shadow: none;
+		display: inline-flex;
+		flex-direction: row;
+		gap: 10px;
+		outline: none;
+		padding: 0;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby:not(:open) > option {
-        display: none;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby:not(:open) > option {
+		display: none;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby:not(:open)::picker(select) {
-        display: none;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby:not(:open)::picker(select) {
+		display: none;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby .orderby-button {
-        appearance: none;
-        background: transparent;
-        border: 0;
-        box-shadow: none;
-        color: inherit;
-        cursor: pointer;
-        display: inline;
-        font: inherit;
-        margin: 0;
-        order: 0;
-        outline: 0;
-        padding: 0;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby .orderby-button {
+		appearance: none;
+		background: transparent;
+		border: 0;
+		box-shadow: none;
+		color: inherit;
+		cursor: pointer;
+		display: inline;
+		font: inherit;
+		margin: 0;
+		order: 0;
+		outline: 0;
+		padding: 0;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby selectedcontent {
-        display: inline;
-        white-space: nowrap;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby selectedcontent {
+		display: inline;
+		white-space: nowrap;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby::picker-icon {
-        background-image: url('data:image/svg+xml;utf8,<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg>');
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: contain;
-        block-size: 1.5em;
-        color: var(--wp--preset--color--theme-2);
-        content: '';
-        flex-shrink: 0;
-        inline-size: 1.5em;
-        order: 1;
-        transition: rotate 0.15s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby::picker-icon {
+		background-image: url('data:image/svg+xml;utf8,<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.0041 10.5547L11.9996 16.0134L5.99512 10.5547L7.00413 9.44482L11.9996 13.9862L16.9951 9.44483L18.0041 10.5547Z" fill="currentColor"></path></svg>');
+		background-position: center;
+		background-repeat: no-repeat;
+		background-size: contain;
+		block-size: 1.5em;
+		color: var(--wp--preset--color--theme-2);
+		content: '';
+		flex-shrink: 0;
+		inline-size: 1.5em;
+		order: 1;
+		transition: rotate 0.15s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby:open::picker-icon {
-        rotate: 180deg;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby:open::picker-icon {
+		rotate: 180deg;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {
-        align-items: stretch;
-        background-color: var(--wp--preset--color--theme-1);
-        border-radius: 0;
-        box-sizing: border-box;
-        color: var(--wp--preset--color--theme-2);
-        display: flex;
-        flex-direction: column;
-        font-size: var(--wp--preset--font-size--medium);
-        gap: 0;
-        line-height: 1.5625;
-        margin-block-start: 12px;
-        min-width: anchor-size(width);
-        padding: 0;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {
+		align-items: stretch;
+		background-color: var(--wp--preset--color--theme-1);
+		border-radius: 0;
+		box-sizing: border-box;
+		color: var(--wp--preset--color--theme-2);
+		display: flex;
+		flex-direction: column;
+		font-size: var(--wp--preset--font-size--medium);
+		gap: 0;
+		line-height: 1.5625;
+		margin-block-start: 12px;
+		min-width: anchor-size(width);
+		padding: 0;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby:open::picker(select) {
-        border: 1px solid var(--wp--preset--color--theme-6);
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby:open::picker(select) {
+		border: 1px solid var(--wp--preset--color--theme-6);
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby option::checkmark {
-        content: '';
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby option::checkmark {
+		content: '';
+	}
 
-    /* Open list items — padding per option so hover fills a padded row. */
-    .woocommerce.wc-block-catalog-sorting select.orderby option {
-        background-color: transparent;
-        box-sizing: border-box;
-        color: var(--wp--preset--color--theme-2);
-        font-size: var(--wp--preset--font-size--medium);
-        gap: 0;
-        line-height: 1.5625;
-        min-block-size: auto;
-        padding: 12px 18px;
-        white-space: nowrap;
-        width: 100%;
-    }
+	/* Open list items — padding per option so hover fills a padded row. */
+	.woocommerce.wc-block-catalog-sorting select.orderby option {
+		background-color: transparent;
+		box-sizing: border-box;
+		color: var(--wp--preset--color--theme-2);
+		font-size: var(--wp--preset--font-size--medium);
+		gap: 0;
+		line-height: 1.5625;
+		min-block-size: auto;
+		padding: 12px 18px;
+		white-space: nowrap;
+		width: 100%;
+	}
 
-    .woocommerce.wc-block-catalog-sorting select.orderby option:enabled:hover,
-    .woocommerce.wc-block-catalog-sorting select.orderby option:focus {
-        background-color: var(--wp--preset--color--theme-5);
-        outline: none;
-    }
+	.woocommerce.wc-block-catalog-sorting select.orderby option:enabled:hover,
+	.woocommerce.wc-block-catalog-sorting select.orderby option:focus {
+		background-color: var(--wp--preset--color--theme-5);
+		outline: none;
+	}
 
-    /* Underline the closed label while the menu is open (Dropdown/Click, 1875:53421). */
-    .woocommerce.wc-block-catalog-sorting select.orderby:open selectedcontent {
-        text-decoration: underline;
-    }
+	/* Underline the closed label while the menu is open (Dropdown/Click, 1875:53421). */
+	.woocommerce.wc-block-catalog-sorting select.orderby:open selectedcontent {
+		text-decoration: underline;
+	}
 }
 
 :where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pills) {
-    gap: var(--wp--preset--spacing--10);
+	gap: var(--wp--preset--spacing--10);
 }
 
 :where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill) {
-    border-color: var(--wp--preset--color--theme-4);
-    border-radius: 0;
-    font-size: var(--wp--preset--font-size--small);
-    font-weight: 400;
-    letter-spacing: 0.06em;
-    line-height: 1.142;
-    padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
-    text-transform: uppercase;
+	border-color: var(--wp--preset--color--theme-4);
+	border-radius: 0;
+	font-size: var(--wp--preset--font-size--small);
+	font-weight: 400;
+	letter-spacing: 0.06em;
+	line-height: 1.142;
+	padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
+	text-transform: uppercase;
 }
 
 .woocommerce-page label.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
-    margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .woocommerce-page label.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name {
-    margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 :where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked)) {
-    background-color: var(--wp--preset--color--theme-2);
+	background-color: var(--wp--preset--color--theme-2);
 }
 
 .wp-block-accordion-heading__toggle:hover .wp-block-accordion-heading__toggle-title {
-    text-decoration: none;
+	text-decoration: none;
 }
 
 .wp-block-woocommerce-product-review-content p {
-    margin-top: var(--wp--preset--spacing--20);
-    margin-bottom: 0;
+	margin-top: var(--wp--preset--spacing--20);
+	margin-bottom: 0;
 }
 
 .wp-block-woocommerce-cart-order-summary-heading-block textarea {
-    padding-left: 0;
+	padding-left: 0;
 }
 
 .wc-block-cart-item__quantity {
-    margin-top: var(--wp--preset--spacing--20);
+	margin-top: var(--wp--preset--spacing--20);
 }
 .wc-block-components-quantity-selector {
-    min-height: 44px;
+	min-height: 44px;
 }
 
 /* Navigation dropdown panel — desktop only.
@@ -280,9 +280,9 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
  * This lives in style.css (rather than theme.json's css field)
  * because that field strips @media queries during sanitization. */
 @media (min-width: 600px) {
-    :root .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
-        background-color: var(--wp--preset--color--theme-1);
-        border: none;
-        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-    }
+	:root .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
+		background-color: var(--wp--preset--color--theme-1);
+		border: none;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+	}
 }

--- a/purple/styles/block/button-1.json
+++ b/purple/styles/block/button-1.json
@@ -1,15 +1,15 @@
 {
-    "$schema": "https://schemas.wp.org/trunk/theme.json",
-    "version": 3,
-    "slug": "button-1",
-    "title": "Contrast",
-    "blockTypes": [
-        "core/button"
-    ],
-    "styles": {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "button-1",
+	"title": "Contrast",
+	"blockTypes": [
+		"core/button"
+	],
+	"styles": {
 		"color": {
 			"background": "var(--wp--preset--color--theme-1)",
 			"text": "var(--wp--preset--color--theme-2)"
 		}
-    }
+	}
 }

--- a/purple/styles/block/post-terms-badge.json
+++ b/purple/styles/block/post-terms-badge.json
@@ -1,42 +1,42 @@
 {
-    "$schema": "https://schemas.wp.org/trunk/theme.json",
-    "version": 3,
-    "slug": "post-terms-badge",
-    "title": "Badge",
-    "blockTypes": [
-        "core/post-terms"
-    ],
-    "styles": {
-        "css": "display: flex; flex-wrap: wrap; gap: var(--wp--preset--spacing--10); justify-content: center;",
-        "typography": {
-            "fontSize": "var(--wp--preset--font-size--small)",
-            "lineHeight": "1.71",
-            "fontWeight": "400"
-        },
-        "elements": {
-            "link": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-2)",
-                    "background": "var(--wp--preset--color--theme-5)"
-                },
-                "typography": {
-                    "textDecoration": "none"
-                },
-                "spacing": {
-                    "padding": {
-                        "top": "4px",
-                        "right": "var(--wp--preset--spacing--10)",
-                        "bottom": "4px",
-                        "left": "var(--wp--preset--spacing--10)"
-                    }
-                },
-                "css": "display: inline-block; box-sizing: border-box;",
-                ":hover": {
-                    "typography": {
-                        "textDecoration": "none"
-                    }
-                }
-            }
-        }
-    }
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "post-terms-badge",
+	"title": "Badge",
+	"blockTypes": [
+		"core/post-terms"
+	],
+	"styles": {
+		"css": "display: flex; flex-wrap: wrap; gap: var(--wp--preset--spacing--10); justify-content: center;",
+		"typography": {
+			"fontSize": "var(--wp--preset--font-size--small)",
+			"lineHeight": "1.71",
+			"fontWeight": "400"
+		},
+		"elements": {
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-2)",
+					"background": "var(--wp--preset--color--theme-5)"
+				},
+				"typography": {
+					"textDecoration": "none"
+				},
+				"spacing": {
+					"padding": {
+						"top": "4px",
+						"right": "var(--wp--preset--spacing--10)",
+						"bottom": "4px",
+						"left": "var(--wp--preset--spacing--10)"
+					}
+				},
+				"css": "display: inline-block; box-sizing: border-box;",
+				":hover": {
+					"typography": {
+						"textDecoration": "none"
+					}
+				}
+			}
+		}
+	}
 }

--- a/purple/styles/block/section-1.json
+++ b/purple/styles/block/section-1.json
@@ -1,52 +1,52 @@
 {
-    "$schema": "https://schemas.wp.org/trunk/theme.json",
-    "version": 3,
-    "slug": "section-1",
-    "title": "Style 1",
-    "blockTypes": [
-        "core/group",
-        "core/columns",
-        "core/column"
-    ],
-    "styles": {
-        "color": {
-            "background": "var(--wp--preset--color--theme-2)",
-            "text": "var(--wp--preset--color--theme-5)"
-        },
-        "blocks": {
-            "core/separator": {
-                "color": {
-                    "text": "color-mix(in srgb, currentColor 25%, transparent)"
-                }
-            },
-            "core/site-tagline": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-5)"
-                }
-            }
-        },
-        "elements": {
-            "button": {
-                "color": {
-                    "background": "var(--wp--preset--color--theme-1)",
-                    "text": "var(--wp--preset--color--theme-2)"
-                },
-                ":hover": {
-                    "color": {
-                        "background": "color-mix(in srgb, var(--wp--preset--color--theme-1) 85%, #000)"
-                    }
-                }
-            },
-            "heading": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-5)"
-                }
-            },
-            "link": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-5)"
-                }
-            }
-        }
-    }
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-1",
+	"title": "Style 1",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--theme-2)",
+			"text": "var(--wp--preset--color--theme-5)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			},
+			"core/site-tagline": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-5)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--theme-1)",
+					"text": "var(--wp--preset--color--theme-2)"
+				},
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--theme-1) 85%, #000)"
+					}
+				}
+			},
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-5)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-5)"
+				}
+			}
+		}
+	}
 }

--- a/purple/styles/block/section-2.json
+++ b/purple/styles/block/section-2.json
@@ -1,52 +1,52 @@
 {
-    "$schema": "https://schemas.wp.org/trunk/theme.json",
-    "version": 3,
-    "slug": "section-2",
-    "title": "Style 2",
-    "blockTypes": [
-        "core/group",
-        "core/columns",
-        "core/column"
-    ],
-    "styles": {
-        "color": {
-            "background": "var(--wp--preset--color--theme-3)",
-            "text": "var(--wp--preset--color--theme-5)"
-        },
-        "blocks": {
-            "core/separator": {
-                "color": {
-                    "text": "color-mix(in srgb, currentColor 25%, transparent)"
-                }
-            },
-            "core/site-tagline": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-5)"
-                }
-            }
-        },
-        "elements": {
-            "button": {
-                "color": {
-                    "background": "var(--wp--preset--color--theme-1)",
-                    "text": "var(--wp--preset--color--theme-2)"
-                },
-                ":hover": {
-                    "color": {
-                        "background": "color-mix(in srgb, var(--wp--preset--color--theme-1) 85%, #000)"
-                    }
-                }
-            },
-            "heading": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-5)"
-                }
-            },
-            "link": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-5)"
-                }
-            }
-        }
-    }
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-2",
+	"title": "Style 2",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--theme-3)",
+			"text": "var(--wp--preset--color--theme-5)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			},
+			"core/site-tagline": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-5)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--theme-1)",
+					"text": "var(--wp--preset--color--theme-2)"
+				},
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--theme-1) 85%, #000)"
+					}
+				}
+			},
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-5)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-5)"
+				}
+			}
+		}
+	}
 }

--- a/purple/styles/block/section-3.json
+++ b/purple/styles/block/section-3.json
@@ -1,52 +1,52 @@
 {
-    "$schema": "https://schemas.wp.org/trunk/theme.json",
-    "version": 3,
-    "slug": "section-3",
-    "title": "Style 3",
-    "blockTypes": [
-        "core/group",
-        "core/columns",
-        "core/column"
-    ],
-    "styles": {
-        "color": {
-            "background": "var(--wp--preset--color--theme-4)",
-            "text": "var(--wp--preset--color--theme-1)"
-        },
-        "blocks": {
-            "core/separator": {
-                "color": {
-                    "text": "color-mix(in srgb, currentColor 25%, transparent)"
-                }
-            },
-            "core/site-tagline": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-1)"
-                }
-            }
-        },
-        "elements": {
-            "button": {
-                "color": {
-                    "background": "var(--wp--preset--color--theme-1)",
-                    "text": "var(--wp--preset--color--theme-2)"
-                },
-                ":hover": {
-                    "color": {
-                        "background": "color-mix(in srgb, var(--wp--preset--color--theme-1) 85%, #000)"
-                    }
-                }
-            },
-            "heading": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-1)"
-                }
-            },
-            "link": {
-                "color": {
-                    "text": "var(--wp--preset--color--theme-1)"
-                }
-            }
-        }
-    }
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-3",
+	"title": "Style 3",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--theme-4)",
+			"text": "var(--wp--preset--color--theme-1)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			},
+			"core/site-tagline": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-1)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--theme-1)",
+					"text": "var(--wp--preset--color--theme-2)"
+				},
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--theme-1) 85%, #000)"
+					}
+				}
+			},
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-1)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-1)"
+				}
+			}
+		}
+	}
 }

--- a/purple/templates/404.html
+++ b/purple/templates/404.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
-    <!-- wp:pattern {"slug":"purple/hidden-404"} /-->
-    <!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
+	<!-- wp:pattern {"slug":"purple/hidden-404"} /-->
+	<!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/purple/templates/product-search-results.html
+++ b/purple/templates/product-search-results.html
@@ -2,23 +2,23 @@
 
 <!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group alignwide is-style-default"
-    style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--90)">
-    <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--90)">
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignwide"><!-- wp:woocommerce/store-notices /-->
 
-        <!-- wp:woocommerce/breadcrumbs /-->
+		<!-- wp:woocommerce/breadcrumbs /-->
 
-        <!-- wp:query-title {"type":"search","level":1,"showPrefix":false,"align":"wide"} /-->
+		<!-- wp:query-title {"type":"search","level":1,"showPrefix":false,"align":"wide"} /-->
 
-        <!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-        <div class="wp-block-group alignwide">
-            <!-- wp:pattern {"slug":"purple/hidden-search-products"} /-->
-        </div>
-        <!-- /wp:group -->
-    </div>
-    <!-- /wp:group -->
+		<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+		<div class="wp-block-group alignwide">
+			<!-- wp:pattern {"slug":"purple/hidden-search-products"} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
 
-    <!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/search.html
+++ b/purple/templates/search.html
@@ -2,12 +2,12 @@
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Archive"},"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50","top":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--90);padding-bottom:var(--wp--preset--spacing--50)">
-    <!-- wp:query-title {"type":"search","align":"wide"} /-->
-    <!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-        <div class="wp-block-group alignwide">
-            <!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%"} /-->
-        </div>
-    <!-- /wp:group -->
+	<!-- wp:query-title {"type":"search","align":"wide"} /-->
+	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+		<div class="wp-block-group alignwide">
+			<!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%"} /-->
+		</div>
+	<!-- /wp:group -->
 	<!-- wp:pattern {"slug":"purple/posts-three-columns"} /-->
 </main>
 <!-- /wp:group -->

--- a/purple/templates/single-product.html
+++ b/purple/templates/single-product.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"className":"woocommerce product","__wooCommerceIsFirstBlock":true,"__wooCommerceIsLastBlock":true,"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|90"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group woocommerce product" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--90)">
 	
-    <!-- wp:pattern {"slug":"purple/hidden-single-product"} /-->
+	<!-- wp:pattern {"slug":"purple/hidden-single-product"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/single.html
+++ b/purple/templates/single.html
@@ -1,66 +1,87 @@
 <!-- wp:template-part {"slug":"header","theme":"purple"} /-->
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group"><!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"style":{"typography":{"textAlign":"center"}}} /-->
-	
-	<!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"var:preset|spacing|10"}},"typography":{"textAlign":"center"}}} /-->
-	
-	<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"center"}}} /-->
-	
-	<!-- wp:post-terms {"term":"category","separator":"","className":"is-style-post-terms-badge","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"var:preset|spacing|30","bottom":"0","left":"0","right":"0"}},"typography":{"textAlign":"center"}}} /-->
-	
-	<!-- wp:post-featured-image {"aspectRatio":"4/3","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}}} /-->
-	
-	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--70)"><!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"full","layout":{"type":"constrained"}} /--></div>
-	<!-- /wp:group --></div>
-	<!-- /wp:group -->
-	
+<main class="wp-block-group"
+	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group"><!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}},"backgroundColor":"theme-6"} -->
-	<hr class="wp-block-separator has-text-color has-theme-6-color has-alpha-channel-opacity has-theme-6-background-color has-background" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0"/>
-	<!-- /wp:separator -->
-	
-	<!-- wp:comments {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
-	<div class="wp-block-comments" style="margin-top:0;margin-bottom:0"><!-- wp:comments-title {"level":3,"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
-	
-	<!-- wp:comment-template -->
-	<!-- wp:columns {"isStackedOnMobile":false,"style":{"spacing":{"blockGap":{"top":"0","left":"16px"},"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
-	<div class="wp-block-columns is-not-stacked-on-mobile" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:column {"width":"34px"} -->
-	<div class="wp-block-column" style="flex-basis:34px"><!-- wp:avatar {"size":34,"isLink":true,"style":{"border":{"radius":"100px"},"spacing":{"margin":{"top":"4px"}}}} /--></div>
-	<!-- /wp:column -->
-	
-	<!-- wp:column {"style":{"spacing":{"blockGap":"8px"}}} -->
-	<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group"><!-- wp:comment-author-name /-->
-	
-	<!-- wp:comment-date {"isLink":false,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
-	
-	<!-- wp:comment-content /-->
-	
-	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex"}} -->
-	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)"><!-- wp:comment-edit-link /-->
-		<!-- wp:comment-reply-link /-->
-	
+	<div class="wp-block-group">
+		<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"style":{"typography":{"textAlign":"center"}}} /-->
+
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"var:preset|spacing|10"}},"typography":{"textAlign":"center"}}} /-->
+
+		<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"center"}}} /-->
+
+		<!-- wp:post-terms {"term":"category","separator":"","className":"is-style-post-terms-badge","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"var:preset|spacing|30","bottom":"0","left":"0","right":"0"}},"typography":{"textAlign":"center"}}} /-->
+
+		<!-- wp:post-featured-image {"aspectRatio":"4/3","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}}} /-->
+
+		<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--70)">
+			<!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"full","layout":{"type":"constrained"}} /-->
+		</div>
+		<!-- /wp:group -->
 	</div>
-	<!-- /wp:group --></div>
-	<!-- /wp:group --></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns -->
-	<!-- /wp:comment-template -->
-	
-	<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<!-- wp:comments-pagination-previous /-->
-	
-	<!-- wp:comments-pagination-next /-->
-	<!-- /wp:comments-pagination -->
-	
-	<!-- wp:post-comments-form {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /--></div>
-	<!-- /wp:comments --></div>
-	<!-- /wp:group --></main>
 	<!-- /wp:group -->
-	
-	<!-- wp:pattern {"slug":"purple/posts-three-columns-left-aligned-heading"} /-->
-	
-	<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->
+
+	<!-- wp:group {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}},"backgroundColor":"theme-6"} -->
+		<hr class="wp-block-separator has-text-color has-theme-6-color has-alpha-channel-opacity has-theme-6-background-color has-background"
+			style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0" />
+		<!-- /wp:separator -->
+
+		<!-- wp:comments {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+		<div class="wp-block-comments" style="margin-top:0;margin-bottom:0">
+			<!-- wp:comments-title {"level":3,"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
+
+			<!-- wp:comment-template -->
+			<!-- wp:columns {"isStackedOnMobile":false,"style":{"spacing":{"blockGap":{"top":"0","left":"16px"},"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
+			<div class="wp-block-columns is-not-stacked-on-mobile"
+				style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50)">
+				<!-- wp:column {"width":"34px"} -->
+				<div class="wp-block-column" style="flex-basis:34px">
+					<!-- wp:avatar {"size":34,"isLink":true,"style":{"border":{"radius":"100px"},"spacing":{"margin":{"top":"4px"}}}} /-->
+				</div>
+				<!-- /wp:column -->
+
+				<!-- wp:column {"style":{"spacing":{"blockGap":"8px"}}} -->
+				<div class="wp-block-column">
+					<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+					<div class="wp-block-group"><!-- wp:comment-author-name /-->
+
+						<!-- wp:comment-date {"isLink":false,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
+
+						<!-- wp:comment-content /-->
+
+						<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex"}} -->
+						<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
+							<!-- wp:comment-edit-link /-->
+							<!-- wp:comment-reply-link /-->
+
+						</div>
+						<!-- /wp:group -->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:column -->
+			</div>
+			<!-- /wp:columns -->
+			<!-- /wp:comment-template -->
+
+			<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:comments-pagination-previous /-->
+
+			<!-- wp:comments-pagination-next /-->
+			<!-- /wp:comments-pagination -->
+
+			<!-- wp:post-comments-form {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
+		</div>
+		<!-- /wp:comments -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:pattern {"slug":"purple/posts-three-columns-left-aligned-heading"} /-->
+
+<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->

--- a/purple/templates/template-blank.html
+++ b/purple/templates/template-blank.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
-    <!-- wp:post-content {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"default"}} /-->
+	<!-- wp:post-content {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"default"}} /-->
 </main>
 <!-- /wp:group -->

--- a/purple/templates/template-page-no-title.html
+++ b/purple/templates/template-page-no-title.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
 
-    <!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/template-page-w-cover.html
+++ b/purple/templates/template-page-w-cover.html
@@ -2,24 +2,24 @@
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
-    <!-- wp:group {"metadata":{"name":"Page Title"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
-    <div class="wp-block-group">
-        <!-- wp:cover {"useFeaturedImage":true,"dimRatio":50,"overlayColor":"theme-2","isUserOverlayColor":true,"isDark":false,"layout":{"type":"constrained"}} -->
-        <div class="wp-block-cover is-light"><span aria-hidden="true"
-                class="wp-block-cover__background has-theme-2-background-color has-background-dim"></span>
-            <div class="wp-block-cover__inner-container">
-                <!-- wp:post-title {"level":1,"style":{"typography":{"textAlign":"center"}},"fontSize":"xx-large"} /-->
-            </div>
-        </div>
-        <!-- /wp:cover -->
-    </div>
-    <!-- /wp:group -->
+	<!-- wp:group {"metadata":{"name":"Page Title"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group">
+		<!-- wp:cover {"useFeaturedImage":true,"dimRatio":50,"overlayColor":"theme-2","isUserOverlayColor":true,"isDark":false,"layout":{"type":"constrained"}} -->
+		<div class="wp-block-cover is-light"><span aria-hidden="true"
+				class="wp-block-cover__background has-theme-2-background-color has-background-dim"></span>
+			<div class="wp-block-cover__inner-container">
+				<!-- wp:post-title {"level":1,"style":{"typography":{"textAlign":"center"}},"fontSize":"xx-large"} /-->
+			</div>
+		</div>
+		<!-- /wp:cover -->
+	</div>
+	<!-- /wp:group -->
 
-    <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group"
-        style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
-        <!-- wp:post-content {"layout":{"type":"constrained"}} /--></div>
-    <!-- /wp:group -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group"
+		style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /--></div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -81,42 +81,42 @@
 		"spacing": {
 			"defaultSpacingSizes": false,
 			"spacingScale": {
-                "steps": 1
-            },
+				"steps": 1
+			},
 			"spacingSizes": [
 				{
 					"name": "2X-Small",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 1 * 1px), calc(var(--wp--custom--spacing-unit) * 1 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 1 * 1px), calc(var(--wp--custom--spacing-unit) * 1 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "10"
 				},
 				{
 					"name": "X-Small",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 2 * 1px), calc(var(--wp--custom--spacing-unit) * 2 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 2 * 1px), calc(var(--wp--custom--spacing-unit) * 2 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "20"
 				},
 				{
 					"name": "Small",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 3 * 1px), calc(var(--wp--custom--spacing-unit) * 3 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 3 * 1px), calc(var(--wp--custom--spacing-unit) * 3 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "30"
 				},
 				{
 					"name": "Regular",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 5 * 1px), calc(var(--wp--custom--spacing-unit) * 5 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 5 * 1px), calc(var(--wp--custom--spacing-unit) * 5 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "50"
 				},
 				{
 					"name": "Large",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 7 * 1px), calc(var(--wp--custom--spacing-unit) * 7 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 7 * 1px), calc(var(--wp--custom--spacing-unit) * 7 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "70"
 				},
 				{
 					"name": "Extra Large",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 9 * 1px), calc(var(--wp--custom--spacing-unit) * 9 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 9 * 1px), calc(var(--wp--custom--spacing-unit) * 9 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "90"
 				},
 				{
 					"name": "2X Large",
-                    "size": "min(calc(var(--wp--custom--spacing-unit) * 14 * 1px), calc(var(--wp--custom--spacing-unit) * 14 * 1px * 100vw / var(--wp--style--global--wide-size)))",
+					"size": "min(calc(var(--wp--custom--spacing-unit) * 14 * 1px), calc(var(--wp--custom--spacing-unit) * 14 * 1px * 100vw / var(--wp--style--global--wide-size)))",
 					"slug": "140"
 				}
 			]
@@ -135,8 +135,8 @@
 								"file:./assets/fonts/inter/InterVariable.woff2"
 							],
 							"fontWeight": "100 900",
-                            "fontStretch": "normal",
-                            "fontStyle": "normal",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
 							"fontFamily": "Inter"
 						},
 						{
@@ -145,7 +145,7 @@
 							],
 							"fontWeight": "100 900",
 							"fontStyle": "italic",
-                            "fontStretch": "normal",
+							"fontStretch": "normal",
 							"fontFamily": "Inter"
 						}
 					]
@@ -251,10 +251,10 @@
 				}
 			},
 			"core/columns": {
-                "spacing": {
-                    "blockGap": "var(--wp--preset--spacing--50)"
-                }
-            },
+				"spacing": {
+					"blockGap": "var(--wp--preset--spacing--50)"
+				}
+			},
 			"core/cover": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-1)"


### PR DESCRIPTION
## Summary
- Convert remaining space-indented Purple files to WordPress-style tab indentation (templates, parts, `style.css`, block style JSON, and `theme.json`).
- Aligns these files with the rest of the theme where PHP sources already use tabs; whitespace-only change, no functional edits.

## Test plan
- [ ] Confirm Site Editor still loads templates (e.g. Page with cover, Single, 404)
- [ ] Spot-check one template and one block style in the editor — layout and styles unchanged
- [ ] Optional: `git diff -w trunk...HEAD` shows no substantive diff


Made with [Cursor](https://cursor.com)