### PR TITLE
Add Product Catalog (No Filters) template and grid patterns (WOOPRD-1519)

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -1,12 +1,16 @@
 <?php
 /**
  * Title: Product grid with filters
- * Slug: purple/hidden-product-grid-with-filters
- * Inserter: no
+ * Slug: purple/product-grid-with-filters
+ * Categories: woo-commerce, purple
+ * Keywords: woo-commerce, products, shop, catalog, grid, filters, sorting, pagination
+ * Description: A product catalog grid with sidebar filters, sorting, and pagination.
+ * Block Types: woocommerce/product-collection
+ * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Product grid with filters","patternName":"purple/hidden-product-grid-with-filters"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Product grid with filters","categories":["woo-commerce","purple"],"patternName":"purple/product-grid-with-filters","description":"A product catalog grid with sidebar filters, sorting, and pagination."},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"22%"} -->
 <div class="wp-block-column" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->
@@ -109,13 +113,15 @@
 <!-- wp:column {"width":"88%"} -->
 <div class="wp-block-column" style="flex-basis:88%"><!-- wp:woocommerce/product-collection {"queryId":27,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
-<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1.5625"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}}}} /--></div>
+<!-- /wp:group -->
 <!-- /wp:woocommerce/product-template -->
 
 <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->

--- a/purple/patterns/product-grid-without-filters.php
+++ b/purple/patterns/product-grid-without-filters.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Title: Product grid without filters
+ * Slug: purple/product-grid-without-filters
+ * Categories: woo-commerce, purple
+ * Keywords: woo-commerce, products, shop, catalog, grid, sorting, pagination
+ * Description: A product catalog grid with sorting and pagination, without sidebar filters.
+ * Block Types: woocommerce/product-collection
+ * Viewport width: 1440
+ */
+?>
+
+<!-- wp:group {"metadata":{"name":"Product grid without filters","categories":["woo-commerce","purple"],"patternName":"purple/product-grid-without-filters","description":"A product catalog grid with sorting and pagination, without sidebar filters."},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:group {"className":"alignwide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p><?php esc_html_e('Sort by:', 'purple');?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:woocommerce/product-collection {"queryId":26,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
+<div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
+<!-- /wp:woocommerce/product-image -->
+
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55"}}} /--></div>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous {"label":"<?php esc_html_e('Previous', 'purple');?>"} /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next {"label":"<?php esc_html_e('Next', 'purple');?>"} /-->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:group -->
+
+<!-- wp:woocommerce/product-collection-no-results -->
+<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p><?php /* Translators: 1. is the start of a 'a' HTML element, 2. is the end of a 'a' HTML element, 3. is the start of a 'a' HTML element, 4. is the end of a 'a' HTML element */ 
+echo sprintf( esc_html__( 'No results found. You can try %1$sclearing any filters%2$s or head to our %3$sstore\'s home.%4$s', 'purple' ), '<a class="wc-link-clear-any-filters" href="' . esc_url( '#' ) . '">', '</a>', '<a class="wc-link-stores-home" href="' . esc_url( '#' ) . '">', '</a>' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
+<!-- /wp:woocommerce/product-collection --></div>
+<!-- /wp:group -->

--- a/purple/templates/archive-product-without-filters.html
+++ b/purple/templates/archive-product-without-filters.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/product-grid-without-filters"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/product-search-results.html
+++ b/purple/templates/product-search-results.html
@@ -18,7 +18,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/templates/taxonomy-product_attribute.html
+++ b/purple/templates/taxonomy-product_attribute.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:pattern {"slug":"purple/hidden-product-grid-with-filters"} /-->
+	<!-- wp:pattern {"slug":"purple/product-grid-with-filters"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -7,6 +7,10 @@
 		{
 			"name": "template-page-w-cover",
 			"title": "Page with Cover"
+		},
+		{
+			"name": "archive-product-without-filters",
+			"title": "Product Catalog (No Filters)"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
## Summary

- Adds `archive-product-without-filters.html` — Product Catalog shell using `purple/product-grid-without-filters` (no sidebar filters).
- Registers the template in `theme.json` as **Product Catalog (No Filters)**.
- Adds `product-grid-without-filters` pattern (i18n, inserter metadata) for sorting + pagination without filters.
- Renames `hidden-product-grid-with-filters` → `product-grid-with-filters`, exposes it in the inserter, and updates catalog template references.

Fixes [WOOPRD-1519](https://linear.app/a8c/issue/WOOPRD-1519/add-template-store-main-option-without-filter-sidebar).

## Test plan

- [ ] Site Editor → Templates: **Product Catalog** (default) still uses filtered grid on `/shop/`.
- [ ] Site Editor → Templates: **Product Catalog (No Filters)** renders shop shell without filter sidebar.
- [ ] Block inserter → Shop: both **Product grid with filters** and **Product grid without filters** patterns appear.
- [ ] `/shop/` (default template): filters sidebar visible.
- [ ] Switch catalog to no-filters template → `/shop/` shows sort + grid only.
- [ ] Product search and attribute archives still use filtered grid template.


Made with [Cursor](https://cursor.com)