### PR TITLE
Internationalise Purple cart page title

### DIFF
--- a/purple/patterns/hidden-cart-page-title.php
+++ b/purple/patterns/hidden-cart-page-title.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Title: Cart page title
+ * Slug: purple/hidden-cart-page-title
+ * Inserter: no
+ */
+?>
+
+<!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"xx-large"} -->
+<h1 class="wp-block-heading alignwide has-xx-large-font-size" style="margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e( 'Cart', 'purple' ); ?></h1>
+<!-- /wp:heading -->

--- a/purple/templates/page-cart.html
+++ b/purple/templates/page-cart.html
@@ -4,9 +4,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained","contentSize":"1060px"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--30)">
 
-	<!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"xx-large"} -->
-	<h1 class="wp-block-heading alignwide has-xx-large-font-size" style="margin-bottom:var(--wp--preset--spacing--30)">Cart</h1>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"purple/hidden-cart-page-title"} /-->
 
 	<!-- wp:woocommerce/store-notices /-->
 


### PR DESCRIPTION
## Summary
- Add `purple/hidden-cart-page-title` hidden pattern with `esc_html_e( 'Cart', 'purple' )`.
- Replace the hardcoded heading in `page-cart.html` with a pattern reference.

Fixes a theme-review finding: block theme templates cannot use PHP translation functions directly, so user-facing copy belongs in PHP patterns (same approach as `hidden-blog-heading` and Assembler's cart title pattern).

## Test plan
- [ ] Open the Cart page on purple.local and confirm the heading still renders as "Cart" with `xx-large` typography.
- [ ] Confirm the heading spacing below the title is unchanged.
- [ ] Switch site language (if available) and verify the string is translatable via the `purple` text domain.


Made with [Cursor](https://cursor.com)