### PR TITLE
Polish Purple templates, catalog toolbar, and site title typography

### DIFF
--- a/purple/parts/checkout-header.html
+++ b/purple/parts/checkout-header.html
@@ -1,8 +1,8 @@
 <!-- wp:group {"metadata":{"name":"Checkout Header"},"style":{"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"
 	style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-	<div class="wp-block-group alignwide" style="padding-top:8px;padding-bottom:8px">
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"10.5px","bottom":"10.5px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group alignwide" style="padding-top:10.5px;padding-bottom:10.5px">
 		<!-- wp:site-title {"level":0,"style":{"typography":{"lineHeight":"1.23"}}} /--></div>
 	<!-- /wp:group -->
 </div>

--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -12,19 +12,19 @@
 
 <!-- wp:group {"metadata":{"name":"Product grid with filters","categories":["woo-commerce","purple"],"patternName":"purple/product-grid-with-filters","description":"A product catalog grid with sidebar filters, sorting, and pagination."},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"22%"} -->
-<div class="wp-block-column" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"22%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:22%"><!-- wp:heading {"level":3,"style":{"margin":{"top":"0","bottom":"0"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->
 <h3 class="wp-block-heading has-medium-font-size" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400;line-height:1.6"><?php esc_html_e('Filter by:', 'purple');?></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"88%"} -->
-<div class="wp-block-column" style="flex-basis:88%"><!-- wp:group {"className":"alignwide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<!-- wp:column {"verticalAlignment":"center","width":"88%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:88%"><!-- wp:group {"className":"alignwide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><?php esc_html_e('Sort by:', 'purple');?></p>
+<!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
+<p class="has-theme-2-color has-text-color has-link-color"><?php esc_html_e('Sort by:', 'purple');?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>

--- a/purple/style.css
+++ b/purple/style.css
@@ -188,6 +188,10 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	font-size: var(--wp--preset--font-size--medium) !important;
 }
 
+.woocommerce.wc-block-catalog-sorting form.woocommerce-ordering {
+	margin-bottom: 0;
+}
+
 .woocommerce.wc-block-catalog-sorting select.orderby {
 	-webkit-appearance: none;
 	appearance: none;

--- a/purple/templates/page-cart.html
+++ b/purple/templates/page-cart.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header","theme":"purple","tagName":"header"} /-->
 
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained","contentSize":"1060px"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--30)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained","contentSize":"1060px"}} -->
+<main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--30)">
 
 	<!-- wp:pattern {"slug":"purple/hidden-cart-page-title"} /-->
 

--- a/purple/templates/page-checkout.html
+++ b/purple/templates/page-checkout.html
@@ -1,14 +1,11 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"purple","tagName":"header"} /-->
 
 <!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
-<main class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:woocommerce/store-notices /-->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0"><!-- wp:woocommerce/store-notices /-->
 
 	<!-- wp:post-content {"align":"wide","layout":{"type":"default"}} /-->
 
-	<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-	<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->
 <!-- /wp:woocommerce/page-content-wrapper -->

--- a/purple/templates/page.html
+++ b/purple/templates/page.html
@@ -1,15 +1,16 @@
 <!-- wp:template-part {"slug":"header","theme":"purple"} /-->
 
-<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
+<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
-	<!-- wp:group {"metadata":{"name":"Page Title"},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group"><!-- wp:post-featured-image /-->
-
-		<!-- wp:post-title {"level":1,"style":{"typography":{"textAlign":"left"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /-->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-featured-image /-->
+	
+		<!-- wp:post-title {"level":1,"style":{"typography":{"textAlign":"left"}}} /-->
 	</div>
 	<!-- /wp:group -->
-
-	<!-- wp:post-content {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} /-->
+	
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/purple/templates/taxonomy-product_attribute.html
+++ b/purple/templates/taxonomy-product_attribute.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group alignwide is-style-default"
-	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--90)">
+	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--90)">
 	<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignwide"><!-- wp:woocommerce/store-notices /-->
 

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -435,7 +435,8 @@
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontStyle": "normal",
 					"fontWeight": "700",
-					"letterSpacing":"0.125rem",
+					"letterSpacing":"0.09em",
+					"lineHeight": "1.2",
 					"textTransform": "uppercase"
 				}
 			},


### PR DESCRIPTION
## Summary
- Standardize static page spacing in `page.html` using main `blockGap` instead of per-block title/content margins.
- Align cart, checkout, and product attribute archive template padding with the rest of the theme.
- Tighten the product grid filters toolbar: vertical alignment, sort label styling, and remove WooCommerce core bottom margin from the catalog sorting form.
- Refine checkout header padding and site title letter-spacing/line-height in `theme.json`.

## Test plan
- [ ] Visit `/my-account/` and a static page — confirm title/content spacing looks even without extra title top margin.
- [ ] Visit `/cart/` and `/checkout/` — confirm top spacing matches other commerce pages.
- [ ] Visit `/shop/` — confirm “Filter by” / “Sort by” row aligns cleanly and the sorting dropdown has no extra gap below it.
- [ ] Check a product attribute archive — confirm top padding looks balanced with the catalog.
- [ ] Inspect checkout header — site title vertical alignment should match the main header.


Made with [Cursor](https://cursor.com)