### PR TITLE
Fix Add to Cart quantity stepper layout (workaround for woocommerce#66140)

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -349,6 +349,40 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 .wc-block-components-quantity-selector {
 	border-color: var(--wp--preset--color--theme-6);
 	border-radius: 0;
+	min-height: 44px;
+}
+
+/* Editor preview uses legacy .qty classes; frontend adds __input. */
+.woocommerce .wc-block-components-quantity-selector input.qty,
+.wc-block-components-quantity-selector input.qty,
+.wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input {
+	-webkit-appearance: textfield;
+	appearance: textfield;
+	background: transparent;
+	border: 0;
+	box-shadow: none;
+	flex: 1 1 auto;
+	margin: 0;
+	min-width: 40px;
+	order: 2;
+	text-align: center;
+	width: auto;
+}
+
+.wc-block-components-quantity-selector input.qty::-webkit-inner-spin-button,
+.wc-block-components-quantity-selector input.qty::-webkit-outer-spin-button,
+.wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input::-webkit-inner-spin-button,
+.wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+
+.wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--minus {
+	order: 1;
+}
+
+.wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--plus {
+	order: 3;
 }
 
 :where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pills) {
@@ -397,10 +431,6 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 
 .wc-block-cart-item__quantity {
 	margin-top: var(--wp--preset--spacing--20);
-}
-
-.wc-block-components-quantity-selector {
-	min-height: 44px;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- Restore compact `− 1 +` stepper layout for Add to Cart + Options quantity fields in the Site Editor and on the frontend.
- Covers both legacy editor placeholder classes (`input-text qty text`) and frontend `wc-block-components-quantity-selector__input` markup.
- Overrides classic WooCommerce `.quantity .qty` width rules that break the block stepper flex layout.

This is a **temporary theme workaround** until WooCommerce fixes the root cause in [woocommerce/woocommerce#66140](https://github.com/woocommerce/woocommerce/issues/66140). Revert this PR once that issue is resolved upstream.

## Test plan
- [ ] Site Editor → Patterns → **Grouped Product Add to Cart + Options** — quantity stepper shows as `− 1 +` (not broken `1 - -`).
- [ ] Site Editor → same for **Simple** and **Variable** product add-to-cart template parts.
- [ ] Frontend grouped product page — stepper layout unchanged and functional.
- [ ] Cart block quantity selector — still renders correctly (min-height consolidated under Single product section).


Made with [Cursor](https://cursor.com)