### PR TITLE
Work around Jetpack Google Fonts dropping bundled Inter

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -132,7 +132,7 @@
 				{
 					"name": "Inter",
 					"slug": "inter",
-					"fontFamily": "Inter",
+					"fontFamily": "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
 					"fontFace": [
 						{
 							"src": [
@@ -722,7 +722,7 @@
 			}
 		},
 		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--inter), system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+			"fontFamily": "var(--wp--preset--font-family--inter)",
 			"fontSize":  "var(--wp--preset--font-size--medium)",
 			"fontStyle": "normal",
 			"fontWeight": "300",


### PR DESCRIPTION
## Summary
- Use a bare `var(--wp--preset--font-family--inter)` in global `styles.typography` so Jetpack's Google Fonts module can detect the preset slug on the front end.
- Move the `system-ui` fallback stack into the Inter font family preset definition, preserving graceful degradation when the bundled font fails to load.

Fixes a front-end regression where Jetpack's deprecated Google Fonts module removes core `wp_print_font_faces()` and fails to print `@font-face` rules when `fontFamily` includes a compound fallback stack. See [Automattic/jetpack#50180](https://github.com/Automattic/jetpack/issues/50180).

## Test plan
- [ ] With Jetpack Google Fonts module **enabled**, view the front end logged out and confirm Inter loads (inspect `wp-fonts-local` / bundled `InterVariable.woff2` in page source).
- [ ] With the module **disabled**, confirm Inter still loads as before.
- [ ] Site Editor → confirm body typography still uses Inter with expected weight and line height.
- [ ] Toggle a typography style variation and confirm alternate font stacks are unaffected.


Made with [Cursor](https://cursor.com)