### PR TITLE
Use Navigation blocks for Purple footer links

### DIFF
--- a/purple/patterns/footer-alternative.php
+++ b/purple/patterns/footer-alternative.php
@@ -54,19 +54,13 @@
 <!-- /wp:columns -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"},"blockGap":"0.63rem"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)"><!-- wp:group {"fontSize":"small","layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group has-small-font-size"><!-- wp:paragraph -->
-<p><a href="#"><?php esc_html_e( 'Shipping & returns', 'purple' ); ?></a></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
 
-<!-- wp:paragraph -->
-<p><a href="/privacy-policy"><?php esc_html_e( 'Privacy policy', 'purple' ); ?></a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><a href="#"><?php esc_html_e( 'Terms & conditions', 'purple' ); ?></a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+<!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"fontSize":"small","layout":{"type":"flex","orientation":"horizontal"}} -->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shipping & returns', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Privacy Policy', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Terms & Conditions', 'purple' ); ?>","url":"#"} /-->
+<!-- /wp:navigation -->
 
 <!-- wp:paragraph {"className":"underline-link","style":{"typography":{"textAlign":"left"},"elements":{"link":{"color":{"text":"var:preset|color|theme-4"}}}},"textColor":"theme-4","fontSize":"small"} -->
 <p class="has-text-align-left underline-link has-theme-4-color has-text-color has-link-color has-small-font-size">&copy; <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php

--- a/purple/patterns/footer.php
+++ b/purple/patterns/footer.php
@@ -37,17 +37,12 @@
 <h4 class="wp-block-heading has-text-align-left"><?php esc_html_e( 'Shop', 'purple' ); ?></h4>
 <!-- /wp:heading -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Ceramics', 'purple' ); ?>","url":"#"} /-->
-
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Furniture', 'purple' ); ?>","url":"#"} /-->
-
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Accessories', 'purple' ); ?>","url":"#"} /-->
-
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Clothing', 'purple' ); ?>","url":"#"} /-->
 <!-- /wp:navigation --></div>
-<!-- /wp:group --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"15%","layout":{"type":"default"}} -->
@@ -55,17 +50,12 @@
 <h4 class="wp-block-heading has-text-align-left"><?php esc_html_e( 'Info', 'purple' ); ?></h4>
 <!-- /wp:heading -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'About', 'purple' ); ?>","url":"#"} /-->
-
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Contact us', 'purple' ); ?>","url":"#"} /-->
-
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'FAQs', 'purple' ); ?>","url":"#"} /-->
-
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Blog', 'purple' ); ?>","url":"#"} /-->
 <!-- /wp:navigation --></div>
-<!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
@@ -89,18 +79,10 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"},"typography":{"lineHeight":"1.71"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="line-height:1.71"><!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="#"><?php esc_html_e( 'Shipping & returns', 'purple' ); ?></a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="#"><?php esc_html_e( 'Privacy Policy', 'purple' ); ?></a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><a href="#"><?php esc_html_e( 'Terms & Conditions', 'purple' ); ?></a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
+<!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|30"},"typography":{"lineHeight":"1.71"}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shipping & returns', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Privacy Policy', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Terms & Conditions', 'purple' ); ?>","url":"#"} /-->
+<!-- /wp:navigation --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- Replace hardcoded paragraph legal links with `core/navigation` blocks in `footer.php` and `footer-alternative.php` so merchants can edit links in the Site Editor.
- Remove redundant wrapper groups around Shop/Info column navigation menus in the default footer.
- Normalise legal link labels (`Privacy Policy`, `Terms & Conditions`) across both footer patterns.

## Test plan
- [ ] Site Editor → Template parts → **Footer** — confirm Shop, Info, and bottom legal links render and are editable via the Navigation block.
- [ ] Swap to **Footer alternative** — confirm legal links row uses Navigation and copyright line still aligns on the opposite side.
- [ ] Front end — confirm all footer links display with expected spacing and small font size.


Made with [Cursor](https://cursor.com)