### PR TITLE
Remove obsolete flex order classes from Purple header nav

### DIFF
--- a/purple/parts/header.html
+++ b/purple/parts/header.html
@@ -6,7 +6,7 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group"><!-- wp:site-title {"level":0} /-->
 
-			<!-- wp:navigation {"overlayMenu":"never","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
+			<!-- wp:navigation {"overlayMenu":"never","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
 		</div>
 		<!-- /wp:group -->
 
@@ -19,7 +19,7 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 			<div class="wp-block-group"><!-- wp:woocommerce/mini-cart /-->
 
-				<!-- wp:navigation {"overlayMenu":"always","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"desktop":false}}},"className":"order-1 md:order-0","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
+				<!-- wp:navigation {"overlayMenu":"always","metadata":{"ignoredHookedBlocks":["woocommerce/customer-account"],"blockVisibility":{"viewport":{"desktop":false}}},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap"}} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>


### PR DESCRIPTION
## Summary
- Remove `order-1 md:order-0` from both Navigation blocks in `parts/header.html`.
- Desktop and mobile nav visibility is already handled via `blockVisibility` viewport settings; the flex order utilities are redundant.

## Test plan
- [ ] Desktop (≥782px): primary nav shows beside site title; hamburger nav is hidden.
- [ ] Tablet/mobile: primary nav is hidden; hamburger nav appears next to mini-cart.
- [ ] Confirm header item order looks correct at 600px, 782px, and 1200px widths.


Made with [Cursor](https://cursor.com)