### PR TITLE
Remove theme attribute from Purple template parts

### DIFF
--- a/purple/templates/page-cart.html
+++ b/purple/templates/page-cart.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"purple","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained","contentSize":"1060px"}} -->
@@ -16,4 +16,4 @@
 <!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
 <!-- /wp:woocommerce/page-content-wrapper -->
 
-<!-- wp:template-part {"slug":"footer","theme":"purple","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/purple/templates/page-checkout.html
+++ b/purple/templates/page-checkout.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"checkout-header","theme":"purple","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"checkout-header","tagName":"header"} /-->
 
 <!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->

--- a/purple/templates/page.html
+++ b/purple/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
@@ -14,4 +14,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/purple/templates/product-search-results.html
+++ b/purple/templates/product-search-results.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"tagName":"main","align":"wide","className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group alignwide is-style-default"
@@ -23,4 +23,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/purple/templates/single.html
+++ b/purple/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group"
@@ -84,4 +84,4 @@
 
 <!-- wp:pattern {"slug":"purple/posts-three-columns-left-aligned-heading"} /-->
 
-<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/purple/templates/template-page-w-cover.html
+++ b/purple/templates/template-page-w-cover.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
@@ -23,4 +23,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
## Summary
- Remove hardcoded `"theme":"purple"` from `core/template-part` blocks in six templates.
- Templates now resolve header, footer, and checkout-header parts from the active theme instead of pinning the slug.

## Files
- `page.html`, `page-cart.html`, `page-checkout.html`
- `single.html`, `product-search-results.html`
- `template-page-w-cover.html`

## Test plan
- [ ] Open each affected template in the Site Editor — header and footer parts still load
- [ ] View a page, single post, cart, checkout, and product search results on purple.local
- [ ] Confirm no broken template parts or missing header/footer on the frontend


Made with [Cursor](https://cursor.com)