### PR TITLE
Replace placeholder with orange sweater in About left-aligned pattern

### DIFF
--- a/purple/patterns/about-left-aligned-heading-text-and-button-right-image.php
+++ b/purple/patterns/about-left-aligned-heading-text-and-button-right-image.php
@@ -29,7 +29,7 @@
 
 <!-- wp:column {"verticalAlignment":"bottom"} -->
 <div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:image {"lightbox":{"enabled":false},"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp" alt="<?php esc_attr_e( 'Placeholder image', 'purple' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/orange-sweater.webp" alt="<?php esc_attr_e( 'Model wearing a colourful knit sweater', 'purple' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>


### PR DESCRIPTION
## Summary
- Update `about-left-aligned-heading-text-and-button-right-image.php` to use `orange-sweater.webp` instead of the placeholder image.
- Add descriptive `esc_attr_e()` alt text matching the hero pattern convention.

## Test plan
- [ ] Insert **Left-aligned heading, text and button, image on the right** in the Site Editor
- [ ] Confirm image loads from theme assets on Linux/case-sensitive filesystems
- [ ] Verify alt text in the block inspector


Made with [Cursor](https://cursor.com)