### PR TITLE
About patterns: sweaters image and about category registration

### DIFF
--- a/purple/patterns/about-category-collection.php
+++ b/purple/patterns/about-category-collection.php
@@ -2,14 +2,14 @@
 /**
  * Title: Collection of categories with images
  * Slug: purple/about-category-collection
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text, image, media
  * Description: A section with a collection of categories with images.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Collection of categories with images","patternName":"purple/about-category-collection","description":"A section with a collection of categories with images.","categories":["purple"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","bottom":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Collection of categories with images","patternName":"purple/about-category-collection","description":"A section with a collection of categories with images.","categories":["about","purple"]},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","bottom":"var:preset|spacing|90"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--90);padding-bottom:var(--wp--preset--spacing--90)"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","textAlign":"center","letterSpacing":"0.08em","lineHeight":"1.28"},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","fontSize":"small"} -->
 <p class="has-text-align-center has-theme-2-color has-text-color has-link-color has-small-font-size" style="letter-spacing:0.08em;line-height:1.28;text-transform:uppercase"><?php esc_html_e( 'Our Selection', 'purple' ); ?></p>

--- a/purple/patterns/about-centered-text.php
+++ b/purple/patterns/about-centered-text.php
@@ -2,14 +2,14 @@
 /**
  * Title: About centered text
  * Slug: purple/about-centered-text
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text
  * Description: A description section aligned center.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Centered text","patternName":"purple/about-centered-text","description":"A description section aligned center.","categories":["purple"]},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|140","bottom":"var:preset|spacing|140"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Centered text","patternName":"purple/about-centered-text","description":"A description section aligned center.","categories":["about","purple"]},"align":"full","className":"is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|140","bottom":"var:preset|spacing|140"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default has-theme-2-color has-text-color has-link-color" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--140);padding-bottom:var(--wp--preset--spacing--140)"><!-- wp:paragraph {"style":{"typography":{"textAlign":"center"}},"fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"><?php esc_html_e('Our products are crafted with meticulous attention to quality, using only the finest materials and ingredients. Designed to deliver exceptional performance, each item undergoes rigorous testing to ensure it meets the highest standards.', 'purple');?></p>
 <!-- /wp:paragraph --></div>

--- a/purple/patterns/about-features-2-columns.php
+++ b/purple/patterns/about-features-2-columns.php
@@ -2,14 +2,14 @@
 /**
  * Title: Heading, image and list of features
  * Slug: purple/about-features-2-columns
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text, image, media
  * Description: A section with a heading, paragraph, a list of features with icons and an image.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["purple"],"name":"Heading, image and list of features","patternName":"purple/about-features-2-columns","description":"A section with a heading, paragraph, a list of features with icons and an image."},"align":"full","className":"alignfull is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"categories":["about","purple"],"name":"Heading, image and list of features","patternName":"purple/about-features-2-columns","description":"A section with a heading, paragraph, a list of features with icons and an image."},"align":"full","className":"alignfull is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|90"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"40%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-bottom:var(--wp--preset--spacing--30);flex-basis:40%"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.12px"}},"fontSize":"small"} -->

--- a/purple/patterns/about-left-aligned-image-description-button.php
+++ b/purple/patterns/about-left-aligned-image-description-button.php
@@ -12,8 +12,8 @@
 <!-- wp:group {"metadata":{"name":"Image on the left, description on the right","categories":["purple"],"patternName":"purple/about-left-aligned-image-description-button","description":"A section with an image on the left, description and button on the right."},"align":"full","className":"is-style-section-2","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull is-style-section-2" style="margin-top:0;margin-bottom:0"><!-- wp:columns {"align":"wide","className":"is-style-default","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns alignwide is-style-default"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp","alt":"<?php esc_attr_e('Placeholder image', 'purple');?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"sizeSlug":"large","style":{"dimensions":{"aspectRatio":"4/3"}},"layout":{"type":"default"}} -->
-<div class="wp-block-cover"><img class="wp-block-cover__image-background size-large" alt="<?php esc_attr_e('Placeholder image', 'purple');?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"placeholder":"Write title…","style":{"typography":{"textAlign":"center"}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/sweaters.webp","alt":"<?php esc_attr_e( 'Stack of folded colourful knit sweaters.', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"isDark":false,"sizeSlug":"full","style":{"dimensions":{"aspectRatio":"4/3"}},"layout":{"type":"default"}} -->
+<div class="wp-block-cover is-light"><img class="wp-block-cover__image-background size-full" alt="<?php esc_attr_e( 'Stack of folded colourful knit sweaters.', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/sweaters.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"placeholder":"Write title…","style":{"typography":{"textAlign":"center"}}} -->
 <p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover --></div>
@@ -22,16 +22,16 @@
 <!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|70","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--70)"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"xx-large"} -->
-<h2 class="wp-block-heading has-xx-large-font-size" style="margin-top:0"><?php esc_html_e('Honest materials', 'purple');?></h2>
+<h2 class="wp-block-heading has-xx-large-font-size" style="margin-top:0"><?php esc_html_e( 'Honest materials', 'purple' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php esc_html_e('We use only responsibly sourced, natural fibers that are as kind to the environment as they are to your skin.', 'purple');?></p>
+<p><?php esc_html_e( 'We use only responsibly sourced, natural fibers that are as kind to the environment as they are to your skin.', 'purple' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"textColor":"theme-1","className":"is-style-outline","style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-1"}}}}} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-theme-1-color has-text-color has-link-color wp-element-button"><?php esc_html_e('Shop now', 'purple');?></a></div>
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-theme-1-color has-text-color has-link-color wp-element-button"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>

--- a/purple/patterns/about-left-aligned-image-description-button.php
+++ b/purple/patterns/about-left-aligned-image-description-button.php
@@ -2,14 +2,14 @@
 /**
  * Title: Image on the left, description on the right
  * Slug: purple/about-left-aligned-image-description-button
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text, media, image
  * Description: A section with an image on the left, description and button on the right.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Image on the left, description on the right","categories":["purple"],"patternName":"purple/about-left-aligned-image-description-button","description":"A section with an image on the left, description and button on the right."},"align":"full","className":"is-style-section-2","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<!-- wp:group {"metadata":{"name":"Image on the left, description on the right","categories":["about","purple"],"patternName":"purple/about-left-aligned-image-description-button","description":"A section with an image on the left, description and button on the right."},"align":"full","className":"is-style-section-2","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull is-style-section-2" style="margin-top:0;margin-bottom:0"><!-- wp:columns {"align":"wide","className":"is-style-default","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns alignwide is-style-default"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/sweaters.webp","alt":"<?php esc_attr_e( 'Stack of folded colourful knit sweaters.', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"isDark":false,"sizeSlug":"full","style":{"dimensions":{"aspectRatio":"4/3"}},"layout":{"type":"default"}} -->

--- a/purple/patterns/about-left-aligned-image-right-text.php
+++ b/purple/patterns/about-left-aligned-image-right-text.php
@@ -2,14 +2,14 @@
 /**
  * Title: Left-aligned image, text on the right
  * Slug: purple/about-left-aligned-image-right-text
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text, intro
  * Description: An intro section with a heading, paragraph, button and image.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["purple"],"name":"Left-aligned image, text on the right","patternName":"purple/about-left-aligned-image-right-text","description":"An intro section with a heading, paragraph, button and image."},"align":"full","className":"alignfull","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|140","bottom":"var:preset|spacing|140"}}},"backgroundColor":"theme-5","layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"categories":["about","purple"],"name":"Left-aligned image, text on the right","patternName":"purple/about-left-aligned-image-right-text","description":"An intro section with a heading, paragraph, button and image."},"align":"full","className":"alignfull","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|140","bottom":"var:preset|spacing|140"}}},"backgroundColor":"theme-5","layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull has-theme-5-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--140);padding-bottom:var(--wp--preset--spacing--140)"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pattern-placeholder.webp","alt":"<?php esc_attr_e('Placeholder image', 'purple');?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"minHeight":25,"minHeightUnit":"rem"} -->

--- a/purple/patterns/about-left-aligned-product-right-text.php
+++ b/purple/patterns/about-left-aligned-product-right-text.php
@@ -2,14 +2,14 @@
 /**
  * Title: Left-aligned product, text on the right
  * Slug: purple/about-left-aligned-product-right-text
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text, intro
  * Description: A section with a product image and a large sized paragraph.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"categories":["purple"],"name":"Left-aligned product, text on the right","description":"A section with a product image and a large sized paragraph.","patternName":"purple/about-left-aligned-product-right-text"},"align":"full","className":"alignfull is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"0"},"dimensions":{"minHeight":""}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"metadata":{"categories":["about","purple"],"name":"Left-aligned product, text on the right","description":"A section with a product image and a large sized paragraph.","patternName":"purple/about-left-aligned-product-right-text"},"align":"full","className":"alignfull is-style-default","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"0"},"dimensions":{"minHeight":""}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"},"padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"backgroundColor":"theme-5"} -->
 <div class="wp-block-columns alignwide has-theme-5-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/product-view1.webp","alt":"<?php esc_attr_e( 'An illustration of folded shirts', 'purple' ); ?>","dimRatio":10,"isDark":false,"style":{"dimensions":{"aspectRatio":"4/3"}},"layout":{"type":"default"}} -->

--- a/purple/patterns/about-left-aligned-text-right-image.php
+++ b/purple/patterns/about-left-aligned-text-right-image.php
@@ -2,14 +2,14 @@
 /**
  * Title: Left-aligned text, image on the right
  * Slug: purple/about-left-aligned-text-right-image
- * Categories: purple
+ * Categories: about, purple
  * Keywords: about, text, intro
  * Description: A section with an image on the right, description on the left.
  * Viewport width: 1440
  */
 ?>
 
-<!-- wp:group {"metadata":{"name":"Left-aligned text, image on the right","categories":["purple"],"patternName":"purple/about-left-aligned-text-right-image","description":"A section with an image on the right, description on the left."},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Left-aligned text, image on the right","categories":["about","purple"],"patternName":"purple/about-left-aligned-text-right-image","description":"A section with an image on the right, description on the left."},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"theme-5","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-theme-5-background-color has-background" style="margin-top:0;margin-bottom:0"><!-- wp:columns {"align":"wide","className":"is-style-default","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
 <div class="wp-block-columns alignwide is-style-default"><!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained","justifyContent":"left"}} -->


### PR DESCRIPTION
## Summary
- Update `about-left-aligned-image-description-button.php` to use `sweaters.webp` instead of the placeholder cover image, with descriptive i18n alt text.
- Register seven About patterns in the `about` category (header + block metadata) so they appear under **About** in the pattern inserter.

## Test plan
- [ ] Open the pattern inserter → **About** and confirm the updated patterns are listed
- [ ] Insert **Image on the left, description on the right** and confirm `sweaters.webp` loads
- [ ] Verify pattern still renders in `page-storefront-alternative-2`