### PR TITLE
Align product collection card typography and carousel spacing

### DIFF
--- a/purple/patterns/woocommerce-product-related-4-column.php
+++ b/purple/patterns/woocommerce-product-related-4-column.php
@@ -21,9 +21,9 @@
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1.5625"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0","top":"var:preset|spacing|20"}},"typography":{"lineHeight":"1.18","textAlign":"left"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55","fontStyle":"normal"}}} /-->
 <!-- /wp:woocommerce/product-template --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-related-products-collection.php
+++ b/purple/patterns/woocommerce-related-products-collection.php
@@ -22,8 +22,8 @@
 <!-- /wp:woocommerce/product-gallery-large-image-next-previous --></div>
 <!-- /wp:group -->
 
-<!-- wp:woocommerce/product-template {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"left":"0","top":"var:preset|spacing|10"}}},"layout":{"type":"flex","justifyContent":"left","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
-<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"var:preset|spacing|30","bottom":"0"}}}} -->
+<!-- wp:woocommerce/product-template {"style":{"typography":{"lineHeight":"1"}},"layout":{"type":"flex","justifyContent":"left","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"}}} -->
 <!-- wp:woocommerce/product-sale-badge /-->
 <!-- /wp:woocommerce/product-image -->
 

--- a/purple/patterns/woocommerce-upsell-products-collection.php
+++ b/purple/patterns/woocommerce-upsell-products-collection.php
@@ -23,7 +23,7 @@
 <!-- /wp:group -->
 
 <!-- wp:woocommerce/product-template {"style":{"typography":{"lineHeight":"1"}},"layout":{"type":"flex","justifyContent":"left","verticalAlignment":"top","flexWrap":"nowrap","orientation":"horizontal"}} -->
-<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"},"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"0","left":"0"}}}} -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"3/4"}}} -->
 <!-- wp:woocommerce/product-sale-badge /-->
 <!-- /wp:woocommerce/product-image -->
 

--- a/purple/style.css
+++ b/purple/style.css
@@ -421,6 +421,10 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	margin-bottom: 0;
 }
 
+.wp-block-woocommerce-product-gallery-large-image-next-previous-is-layout-flex {
+	gap: 0;
+}
+
 /* ==========================================================================
    WooCommerce — Cart
    ========================================================================== */


### PR DESCRIPTION
## Summary
- Update `woocommerce-product-related-4-column.php` product card title and price to large font sizes with adjusted line heights.
- Remove redundant top margins on carousel product images in related and upsell collection patterns.
- Set `gap: 0` on product gallery carousel navigation flex layout in `style.css`.

## Test plan
- [ ] View a single product page and check related/upsell carousels
- [ ] Confirm product title and price sizing in the 4-column related products pattern
- [ ] Verify carousel prev/next controls spacing


Made with [Cursor](https://cursor.com)