### PR TITLE
Register the add-to-cart-with-options template parts in Purple's theme.json

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -760,6 +760,26 @@
 			"area": "uncategorized",
 			"name": "mini-cart",
 			"title": "Mini Cart"
+		},
+		{
+			"area": "uncategorized",
+			"name": "simple-product-add-to-cart-with-options",
+			"title": "Simple Product Add to Cart with Options"
+		},
+		{
+			"area": "uncategorized",
+			"name": "variable-product-add-to-cart-with-options",
+			"title": "Variable Product Add to Cart with Options"
+		},
+		{
+			"area": "uncategorized",
+			"name": "grouped-product-add-to-cart-with-options",
+			"title": "Grouped Product Add to Cart with Options"
+		},
+		{
+			"area": "uncategorized",
+			"name": "external-product-add-to-cart-with-options",
+			"title": "External Product Add to Cart with Options"
 		}
 	],
 	"version": 3,


### PR DESCRIPTION
## What

Register the four product-type template parts consumed by the WooCommerce **Add to Cart with Options** block in `theme.json`'s `templateParts`, with proper titles:

- `simple-product-add-to-cart-with-options` → "Simple Product Add to Cart with Options"
- `variable-product-add-to-cart-with-options` → "Variable Product Add to Cart with Options"
- `grouped-product-add-to-cart-with-options` → "Grouped Product Add to Cart with Options"
- `external-product-add-to-cart-with-options` → "External Product Add to Cart with Options"

## Why

Follow-up to #289 — the last piece of the theme-review finding about unregistered template parts. The parts render fine without registration, but showed raw slugs instead of human titles in the Site Editor. With this, all 10 remaining parts in `parts/` are registered.

## Testing

- `theme.json` parses; all `templateParts` entries verified against files in `parts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)