### PR TITLE
Align Purple navigation dropdowns exactly with the header bottom edge

### DIFF
--- a/purple/assets/js/navigation-dropdown.js
+++ b/purple/assets/js/navigation-dropdown.js
@@ -37,12 +37,10 @@
 					return;
 				}
 
-				// Land the panel top on the header bottom. Pull up 1px so the
-				// hairline reads flush on retina without a hero seam.
+				// Land the panel top exactly on the header bottom.
 				var offset =
 					Math.round( header.getBoundingClientRect().bottom ) -
-					item.getBoundingClientRect().bottom -
-					1;
+					item.getBoundingClientRect().bottom;
 
 				header.style.setProperty(
 					'--purple-nav-dropdown-offset',

--- a/purple/style.css
+++ b/purple/style.css
@@ -517,14 +517,14 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 				left: 0;
 				right: 0;
 				top: 100%;
-				height: var(--purple-nav-dropdown-offset, calc(1.875rem + 0.6875rem));
+				height: var(--purple-nav-dropdown-offset, 31.5px);
 				background: transparent;
 				pointer-events: auto;
 				z-index: 2;
 			}
 
 			& > .wp-block-navigation__submenu-container {
-				top: calc(100% + var(--purple-nav-dropdown-offset, calc(1.875rem + 0.6875rem)));
+				top: calc(100% + var(--purple-nav-dropdown-offset, 31.5px));
 				left: -1.25rem;
 				z-index: 3;
 
@@ -534,7 +534,7 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 					left: 0;
 					right: 0;
 					bottom: 100%;
-					height: var(--purple-nav-dropdown-offset, calc(1.875rem + 0.6875rem));
+					height: var(--purple-nav-dropdown-offset, 31.5px);
 					background: transparent;
 					pointer-events: auto;
 				}


### PR DESCRIPTION
## What

- **`assets/js/navigation-dropdown.js`** — remove the 1px pull-up compensation so desktop dropdown panels land exactly on the header's bottom edge (design preference confirmed against the mockups' intent).
- **`style.css`** — replace the stale `calc(1.875rem + 0.6875rem)` (41px) fallback for `--purple-nav-dropdown-offset` with the measured `31.5px` in all three usages.

## Why

The 41px fallback was tuned for an older, taller header. Anywhere the JS doesn't run — the Site Editor canvas, the pre-JS first paint, no-JS visitors — dropdowns floated ~10px below the header with a visible gap (most noticeable when editing the header template part). The corrected value was measured from the live DOM: header group bottom (326) − nav item bottom (294.5) = 31.5px, which is stable across viewport widths because the header row height is set by the fixed-size icon buttons.

With the fallback correct, no editor-specific override is needed: editor and front end now match by construction, and the JS still measures and fine-tunes on the front for customized headers.

## Testing

- Site Editor: dropdown panel sits flush on the header bottom edge when editing the header template part.
- Front end: hover dropdowns land identically (JS-measured); verified at multiple browser zoom levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)