### PR TITLE
Animate Purple accordion panels with pure CSS and fix the load flash

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -38,8 +38,8 @@
 <div class="wp-block-column" style="flex-basis:22%"><!-- wp:woocommerce/product-filters {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
 <div class="wp-block-woocommerce-product-filters wc-block-product-filters"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
 <div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px;margin-top:0;margin-bottom:0"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"0"}}}} -->
-<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Price', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px;margin-top:0;margin-bottom:0"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|10"}}}} -->
+<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Price', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->
 
 <!-- wp:accordion-panel {"style":{"spacing":{"blockGap":"0"}}} -->
@@ -56,8 +56,8 @@
 <!-- /wp:accordion-item -->
 
 <!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
-<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4} -->
-<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Rating', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Rating', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->
 
 <!-- wp:accordion-panel {"style":{"spacing":{"blockGap":"0"}}} -->
@@ -74,8 +74,8 @@
 <!-- /wp:accordion-item -->
 
 <!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
-<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4} -->
-<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Color', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Color', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->
 
 <!-- wp:accordion-panel {"style":{"spacing":{"blockGap":"0"}}} -->
@@ -92,8 +92,8 @@
 <!-- /wp:accordion-item -->
 
 <!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
-<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4} -->
-<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Status', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
+<div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+<h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e('Status', 'purple');?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->
 
 <!-- wp:accordion-panel {"style":{"spacing":{"blockGap":"0"}}} -->

--- a/purple/style.css
+++ b/purple/style.css
@@ -424,6 +424,43 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	text-decoration: none;
 }
 
+/* Closed accordion panels are server-rendered without [hidden] — the
+ * Interactivity API only applies it after hydration — so they flash open on
+ * load (and would animate shut with the transition below). Collapse them
+ * from first paint via the server-rendered aria-expanded state. Scoped to
+ * scripting: enabled so no-JS visitors keep the all-panels-open fallback. */
+@media (scripting: enabled) {
+	.wp-block-accordion-heading:has([aria-expanded="false"]) + .wp-block-accordion-panel {
+		height: 0;
+		overflow: visible clip;
+	}
+}
+
+/* Animate accordion panels open/closed. Pure CSS: interpolate-size lets
+ * height transition to auto; allow-discrete + @starting-style animate
+ * across the [hidden] display swap. Unsupported browsers snap as before. */
+@media not (prefers-reduced-motion) {
+	@supports (interpolate-size: allow-keywords) {
+		.wp-block-accordion-panel {
+			interpolate-size: allow-keywords;
+			height: auto;
+			overflow: visible clip;
+			transition:
+				height 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+				content-visibility 0.25s allow-discrete,
+				display 0.25s allow-discrete;
+
+			@starting-style {
+				height: 0;
+			}
+		}
+
+		.wp-block-accordion-panel[hidden] {
+			height: 0;
+		}
+	}
+}
+
 .wp-block-woocommerce-product-review-content p {
 	margin-top: var(--wp--preset--spacing--20);
 	margin-bottom: 0;


### PR DESCRIPTION
## What

**`style.css` — smooth accordion open/close, no JS:**

- Transition panels between `height: 0` and `height: auto` using `interpolate-size: allow-keywords`, with `transition-behavior: allow-discrete` + `@starting-style` to animate across the `[hidden]` display swap. Wrapped in `@supports` + `@media not (prefers-reduced-motion)` — unsupported browsers and reduced-motion users keep today's instant snap.
- **Load-flash fix:** closed panels are server-rendered *without* `[hidden]` (the Interactivity API applies it only after hydration), so they flashed open on load — which the new transition turned into a jarring animated collapse. Closed panels now collapse from first paint via the server-rendered `aria-expanded="false"` state, scoped to `@media (scripting: enabled)` so no-JS visitors keep the accessible all-panels-open fallback.
- `overflow: visible clip` (block-axis clip only) so focus rings, slider thumbs, and checkbox edges aren't cut off horizontally.

**`patterns/product-grid-with-filters.php`:** tighten the filter accordion heading padding (`spacing-10` block padding on the toggles).

## Why

The product filter accordions (and any future accordion use) snapped open/closed abruptly. This adds the smooth motion the design calls for with ~30 lines of CSS, no scripts, no markup changes, and no accessibility trade-offs: `hidden`/`aria-expanded` still convey all state; CSS only animates the geometry.

## Testing

- Shop page: panels animate open/closed at 0.25s with the theme's standard easing; no flash on load; no horizontal cut-off of filter controls.
- Reduced motion: instant toggles, no flash.
- `php -l` passes on the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)