### PR TITLE
Update Purple footer navigation link copy

### DIFF
--- a/purple/patterns/footer-alternative.php
+++ b/purple/patterns/footer-alternative.php
@@ -57,7 +57,7 @@
 <div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
 
 <!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"fontSize":"small","layout":{"type":"flex","orientation":"horizontal"}} -->
-<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shipping & returns', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shipping & Returns', 'purple' ); ?>","url":"#"} /-->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Privacy Policy', 'purple' ); ?>","url":"#"} /-->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Terms & Conditions', 'purple' ); ?>","url":"#"} /-->
 <!-- /wp:navigation -->

--- a/purple/patterns/footer.php
+++ b/purple/patterns/footer.php
@@ -38,10 +38,10 @@
 <!-- /wp:heading -->
 
 <!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Ceramics', 'purple' ); ?>","url":"#"} /-->
-<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Furniture', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Cardigans', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Sweaters', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shirts', 'purple' ); ?>","url":"#"} /-->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Accessories', 'purple' ); ?>","url":"#"} /-->
-<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Clothing', 'purple' ); ?>","url":"#"} /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:column -->
 
@@ -80,7 +80,7 @@
 <!-- /wp:group -->
 
 <!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|30"},"typography":{"lineHeight":"1.71"}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shipping & returns', 'purple' ); ?>","url":"#"} /-->
+<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shipping & Returns', 'purple' ); ?>","url":"#"} /-->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Privacy Policy', 'purple' ); ?>","url":"#"} /-->
 <!-- wp:navigation-link {"label":"<?php esc_html_e( 'Terms & Conditions', 'purple' ); ?>","url":"#"} /-->
 <!-- /wp:navigation --></div>


### PR DESCRIPTION
## What

- **`patterns/footer.php`** — replace the leftover category links (Ceramics, Furniture, Clothing) with apparel-store ones matching Purple's positioning: Cardigans, Sweaters, Shirts, Accessories — consistent with the shop categories used elsewhere in the theme (e.g. the category collection pattern).
- **Both footers** — "Shipping & returns" → "Shipping & Returns", matching the title case of the adjacent Privacy Policy and Terms & Conditions links.

## Testing

- `php -l` passes on both patterns; all labels remain wrapped in `esc_html_e( …, 'purple' )`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)