### PR TITLE
Hide the WooCommerce coming-soon social links template part

### DIFF
--- a/purple/functions.php
+++ b/purple/functions.php
@@ -85,6 +85,49 @@ if ( ! function_exists( 'purple_unregister_patterns' ) ) :
 
 endif;
 
+if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
+	/**
+	 * Hide WooCommerce template parts the theme doesn't use from the Site Editor.
+	 *
+	 * Companion to purple_unregister_patterns(): template parts have no
+	 * unregister API — WooCommerce injects them into template queries with its
+	 * own get_block_templates filter (priority 10) — so they are filtered out
+	 * of query results here instead. This only affects listings; rendering a
+	 * template part goes through get_block_file_template and is unaffected,
+	 * and a copy customized in the editor is stored under a different ID, so
+	 * it would remain visible.
+	 *
+	 * @param WP_Block_Template[] $templates     Found templates.
+	 * @param array               $query         Template query arguments.
+	 * @param string              $template_type wp_template or wp_template_part.
+	 * @return WP_Block_Template[]
+	 */
+	function purple_hide_woocommerce_template_parts( array $templates, array $query, string $template_type ): array {
+		if ( 'wp_template_part' !== $template_type ) {
+			return $templates;
+		}
+
+		$hidden_template_part_ids = array(
+			// Referenced only by WooCommerce's coming-soon patterns, which
+			// purple_unregister_patterns() removes; Purple ships its own
+			// coming-soon template.
+			'woocommerce//coming-soon-social-links',
+		);
+
+		return array_values(
+			array_filter(
+				$templates,
+				static function ( $template ) use ( $hidden_template_part_ids ) {
+					return ! in_array( $template->id, $hidden_template_part_ids, true );
+				}
+			)
+		);
+	}
+
+endif;
+
+add_filter( 'get_block_templates', 'purple_hide_woocommerce_template_parts', 20, 3 );
+
 if ( ! function_exists( 'purple_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.


### PR DESCRIPTION
## What

**`functions.php`:** add `purple_hide_woocommerce_template_parts()`, hooked to `get_block_templates` at priority 20, removing the WooCommerce-provided `coming-soon-social-links` template part (`woocommerce//coming-soon-social-links`) from `wp_template_part` query results so it no longer appears in the Site Editor.

## Why

WooCommerce ships `coming-soon-social-links.html` as a file-based template part and injects it into the Site Editor's Template Parts list via its own `get_block_templates` filter (`BlockTemplatesController`, priority 10) — unconditionally, with no opt-out filter. It also isn't registered through the WP template registry (WooCommerce only uses `register_block_template()` for full templates), so `unregister_block_template()` can't remove it, and it isn't a block pattern, so `purple_unregister_patterns()` can't either.

The part is irrelevant to Purple: the theme ships its own `templates/coming-soon.html` (which only references the `purple/coming-soon` pattern), and `purple_unregister_patterns()` already removes all of WooCommerce's `page-coming-soon-*` patterns — the only things that embed this part. That leaves it as an orphaned entry in the editor UI.

Filtering query results at a later priority is safe by construction:

- **Listings only.** Rendering a `core/template-part` block goes through the separate `get_block_file_template` path, so even stray content referencing the part would still render.
- **Matched by ID, not slug.** A copy customized by a merchant in the editor is stored in the DB under a different ID (`woocommerce/woocommerce//…` or the theme's), so user-created content is never hidden.

Verified the same injection mechanism exists in both WC 10.9.4 (current release) and trunk (11.0), so this won't need revisiting at the next WooCommerce major.

## Testing

- `php -l` passes on `functions.php`.
- Site Editor → Patterns → Template Parts: "Coming soon social links" no longer listed; all Purple parts (header, footer, mini-cart, checkout header, add-to-cart variants) still present.
- Coming soon mode still renders Purple's own coming-soon template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)