### PR TITLE
Fix the coming-soon social links template part not being hidden

### DIFF
--- a/purple/functions.php
+++ b/purple/functions.php
@@ -93,9 +93,9 @@ if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
 	 * unregister API — WooCommerce injects them into template queries with its
 	 * own get_block_templates filter (priority 10) — so they are filtered out
 	 * of query results here instead. This only affects listings; rendering a
-	 * template part goes through get_block_file_template and is unaffected,
-	 * and a copy customized in the editor is stored under a different ID, so
-	 * it would remain visible.
+	 * template part goes through get_block_file_template and is unaffected.
+	 * Copies customized in the editor have the 'custom' source and are kept,
+	 * so user-edited content is never hidden.
 	 *
 	 * @param WP_Block_Template[] $templates     Found templates.
 	 * @param array               $query         Template query arguments.
@@ -107,18 +107,19 @@ if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
 			return $templates;
 		}
 
-		$hidden_template_part_ids = array(
+		$hidden_template_part_slugs = array(
 			// Referenced only by WooCommerce's coming-soon patterns, which
 			// purple_unregister_patterns() removes; Purple ships its own
 			// coming-soon template.
-			'woocommerce//coming-soon-social-links',
+			'coming-soon-social-links',
 		);
 
 		return array_values(
 			array_filter(
 				$templates,
-				static function ( $template ) use ( $hidden_template_part_ids ) {
-					return ! in_array( $template->id, $hidden_template_part_ids, true );
+				static function ( $template ) use ( $hidden_template_part_slugs ) {
+					return 'custom' === $template->source
+						|| ! in_array( $template->slug, $hidden_template_part_slugs, true );
 				}
 			)
 		);


### PR DESCRIPTION
## What

**`functions.php`:** fix `purple_hide_woocommerce_template_parts()` (added in #294), which never matched anything. Match the hidden template part by **slug** instead of ID, and keep any entry with the `custom` source.

## Why

#294 matched on the ID `woocommerce//coming-soon-social-links`, but WooCommerce builds its file-based template parts with `BlockTemplateUtils::PLUGIN_SLUG` (`woocommerce/woocommerce`), so the real ID is `woocommerce/woocommerce//coming-soon-social-links` — the filter fired but removed nothing, and the part stayed visible in the Site Editor.

Matching by slug is robust to the ID form, and the `'custom' === $template->source` guard now carries the "never hide user content" property: a copy a merchant customized in the Site Editor is stored in the DB with the `custom` source (it can share the same ID as the bundled file, so the previous ID-based reasoning was wrong there too) and remains listed.

## Testing

- Exercised the filter directly with objects shaped like WooCommerce 10.9.4 builds them (`build_template_result_from_file` / DB copies):
  - `woocommerce/woocommerce//coming-soon-social-links` with `plugin` source → hidden ✓
  - Same ID with `custom` source (merchant-edited copy) → kept ✓
  - `purple//header`, `woocommerce/woocommerce//mini-cart` → kept ✓
  - `wp_template` queries → untouched ✓
- `php -l` passes on `functions.php`.
- Please re-check the Site Editor → Patterns → Template Parts list on the dev site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)