### PR TITLE
Ignore local Claude Code configuration directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ logs/
 # Code analyzer output and env
 changes.json
 .env
+
+# Claude Code local configuration
+.claude/


### PR DESCRIPTION
## What

Add `.claude/` to the root `.gitignore`.

## Why

The `.claude` directory holds personal, machine-local Claude Code settings — permission allowlists in `settings.local.json` — that must never be committed to the repo or ship inside a packaged theme. It previously lived (untracked) inside `purple/`; it now lives at the repo root, and this rule guarantees neither location can ever be added by accident.

If we ever want to commit shared project config (e.g. a team `.claude/settings.json`), the rule can be narrowed to `.claude/settings.local.json` at that point.

## Testing

- `git check-ignore -v .claude purple/.claude` matches both paths against the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)