### PR TITLE
Lighten the cover overlay in the page-with-cover template

### DIFF
--- a/purple/templates/template-page-w-cover.html
+++ b/purple/templates/template-page-w-cover.html
@@ -4,9 +4,8 @@
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
 	<!-- wp:group {"metadata":{"name":"Page Title"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group">
-		<!-- wp:cover {"useFeaturedImage":true,"dimRatio":50,"overlayColor":"theme-2","isUserOverlayColor":true,"isDark":false,"layout":{"type":"constrained"}} -->
-		<div class="wp-block-cover is-light"><span aria-hidden="true"
-				class="wp-block-cover__background has-theme-2-background-color has-background-dim"></span>
+		<!-- wp:cover {"useFeaturedImage":true,"dimRatio":20,"overlayColor":"theme-2","isUserOverlayColor":true,"isDark":false,"layout":{"type":"constrained"}} -->
+		<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-20 has-background-dim"></span>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:post-title {"level":1,"style":{"typography":{"textAlign":"center"}},"fontSize":"xx-large"} /-->
 			</div>
@@ -15,9 +14,8 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group"
-		style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
 		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
## What

`templates/template-page-w-cover.html`:

- Reduce the featured-image cover overlay `dimRatio` from 50 to 20 (markup updated with the matching `has-background-dim-20` class).
- Switch the post-content wrapper group from `constrained` to `default` layout — the inner `core/post-content` block already applies its own constrained layout, so the outer constraint was redundant.

## Why

A 50% overlay muted featured images too much; 20% keeps the title legible while letting the image read. The layout change removes a doubled width constraint around page content.

## Testing

- Page using the "Page with cover" template: featured image visibly brighter behind the title; page content width unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)