### PR TITLE
Replace placeholder copy in the contact pattern description

### DIFF
--- a/purple/patterns/contact-form-with-address-and-image.php
+++ b/purple/patterns/contact-form-with-address-and-image.php
@@ -17,7 +17,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"is-contact-description"} -->
-<p class="is-contact-description"><?php esc_html_e( 'Navigating life\'s intricate fabric, choices unfold paths to the extraordinary, demanding creativity, curiosity, and courage for a truly fulfilling journey.', 'purple' ); ?></p>
+<p class="is-contact-description"><?php esc_html_e( 'You are always welcome to visit our flagship store, where you have the opportunity to try on our garments and purchase directly in the shop.', 'purple' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
## What

`patterns/contact-form-with-address-and-image.php`: replace the abstract placeholder paragraph ("Navigating life's intricate fabric…") with store-appropriate copy inviting visitors to the flagship store.

## Why

The old text was filler that didn't fit a shop's contact page; the new copy matches the pattern's purpose (address + visit information) and reads naturally for a demo store.

## Testing

- `php -l` passes on the pattern.
- String remains wrapped in `esc_html_e( …, 'purple' )` for i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)