### PR TITLE
Widen the single post header and fix the posts pattern query

### DIFF
--- a/purple/patterns/posts-three-columns-center-aligned-heading.php
+++ b/purple/patterns/posts-three-columns-center-aligned-heading.php
@@ -20,7 +20,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
 <!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
 

--- a/purple/templates/single.html
+++ b/purple/templates/single.html
@@ -5,13 +5,17 @@
 	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
-		<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"style":{"typography":{"textAlign":"center"}}} /-->
+		<!-- wp:group {"align":"wide","layout":{"type":"constrained","contentSize":"960px"}} -->
+		<div class="wp-block-group alignwide">
+			<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"style":{"typography":{"textAlign":"center"}}} /-->
 
-		<!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"var:preset|spacing|10"}},"typography":{"textAlign":"center"}}} /-->
+			<!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"var:preset|spacing|10"}},"typography":{"textAlign":"center"}}} /-->
 
-		<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"center"}}} /-->
+			<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"center"}}} /-->
 
-		<!-- wp:post-terms {"term":"category","separator":"","className":"is-style-post-terms-badge","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"var:preset|spacing|30","bottom":"0","left":"0","right":"0"}},"typography":{"textAlign":"center"}}} /-->
+			<!-- wp:post-terms {"term":"category","separator":"","className":"is-style-post-terms-badge","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"var:preset|spacing|30","bottom":"0","left":"0","right":"0"}},"typography":{"textAlign":"center"}}} /-->
+		</div>
+		<!-- /wp:group -->
 
 		<!-- wp:post-featured-image {"aspectRatio":"4/3","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}}} /-->
 


### PR DESCRIPTION
## What

- **`templates/single.html`:** wrap the post date, title, excerpt, and category badges in an `alignwide` group with a 960px content width, giving the post header more room while the featured image and content keep their existing widths.
- **`patterns/posts-three-columns-center-aligned-heading.php`:** set the query block's `inherit` to `false` so the pattern always lists the three latest posts with its own query instead of inheriting the page's main query.

## Why

The single-post header felt cramped at the default content width. And with `inherit: true`, the posts pattern only worked in archive-style contexts — this pattern is used in `page-storefront.php` (a static front-page pattern), where the inherited page query has no posts to show.

The plain `posts-three-columns` pattern keeps `inherit: true` deliberately: it's used in `home.html` / `index.html` / `archive.html` / `search.html`, where inheriting the main query (and its pagination) is correct.

## Testing

- `php -l` passes on the pattern.
- Single post: header cluster renders at 960px, featured image/content unchanged.
- Storefront page: the pattern shows the three latest posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)