### PR TITLE
Add a top margin between the comment form and the reply title

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -356,6 +356,9 @@
 					"blockGap": "var(--wp--preset--spacing--30)"
 				}
 			},
+			"core/post-comments-form": {
+				"css": "& .comment-form { margin-top: var(--wp--preset--spacing--20); }"
+			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",


### PR DESCRIPTION
## Description

On single posts, the comment form (`#commentform`) sat flush against the "Leave a Reply" heading. This adds a small gap between the two.

Since `theme.json` block styles can only target the block's outer wrapper (`.wp-block-post-comments-form`), this uses the per-block `css` property to reach the inner form element, following the same `&` pattern already used for the search input and table cells:

```json
"core/post-comments-form": {
    "css": "& .comment-form { margin-top: var(--wp--preset--spacing--20); }"
}
```

## Testing

1. Open a single post with comments enabled.
2. Scroll to the "Leave a Reply" section.
3. Confirm there is now a spacing--20 gap between the heading and the comment form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)