### PR TITLE
Stop inheriting the query and show the three latest posts in the three-column posts pattern

### DIFF
--- a/purple/patterns/posts-three-columns-left-aligned-heading.php
+++ b/purple/patterns/posts-three-columns-left-aligned-heading.php
@@ -22,7 +22,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":"0","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
 <!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
 


### PR DESCRIPTION
## Description

The three-column posts pattern inherited the main query. On single posts (where it renders as "More from the journal") the inherited query isn't a list of posts, and elsewhere it could return up to 10 posts, overflowing the three-column grid into uneven rows.

The pattern now uses its own query: the three latest posts, one full row of the grid, consistent wherever the pattern is used.

## Testing

1. Open a single post and scroll to the "More from the journal" section.
2. Confirm it shows the three most recent posts in one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)