### PR TITLE
Add a larger top margin to post content headings and tighten it for consecutive headings

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -34,6 +34,18 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
+/*
+ * Tighten margin when a heading follows another heading in post content.
+ * The extra top-margin in theme.json signals a section break above; when
+ * two headings are adjacent the subordinate one should sit closer to its
+ * parent rather than read as a new section. The class is unwrapped from
+ * :where() so we beat the theme.json-generated `:root :where(...)` rule
+ * (which is 0,1,0 specificity from :root).
+ */
+.wp-block-post-content :is(h1, h2, h3, h4, h5, h6) + :is(h1, h2, h3, h4, h5, h6) {
+	margin-top: var(--wp--style--block-gap);
+}
+
 /* ==========================================================================
    WooCommerce — Checkout
    ========================================================================== */

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -359,6 +359,17 @@
 			"core/post-comments-form": {
 				"css": "& .comment-form { margin-top: var(--wp--preset--spacing--20); }"
 			},
+			"core/post-content": {
+				"elements": {
+					"heading": {
+						"spacing": {
+							"margin": {
+								"top": "var(--wp--preset--spacing--50)"
+							}
+						}
+					}
+				}
+			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",


### PR DESCRIPTION
## Description

Headings in post content now get a `spacing--50` top margin via `theme.json`, so each heading reads as a section break rather than sitting at the default block gap from the preceding paragraph.

When a heading directly follows another heading (e.g. an h3 under its h2), the subordinate heading should stay close to its parent instead of reading as a new section, so a `style.css` rule resets the margin between adjacent headings back to the block gap. The selector is kept outside `:where()` on purpose — it needs to beat the `:root :where(...)` rule that theme.json generates.

## Testing

1. Create a post with a paragraph followed by an h2 — the gap above the h2 should be noticeably larger than the regular block gap.
2. Add an h3 directly after the h2 — the gap between the two headings should be the regular block gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)