### PR TITLE
Tighten the gap between post term badges

### DIFF
--- a/purple/styles/block/post-terms-badge.json
+++ b/purple/styles/block/post-terms-badge.json
@@ -7,7 +7,7 @@
 		"core/post-terms"
 	],
 	"styles": {
-		"css": "display: flex; flex-wrap: wrap; gap: var(--wp--preset--spacing--10); justify-content: center;",
+		"css": "display: flex; flex-wrap: wrap; gap: 2px; justify-content: center;",
 		"typography": {
 			"fontSize": "var(--wp--preset--font-size--small)",
 			"lineHeight": "1.71",


### PR DESCRIPTION
## Description

The badge style for post terms used `spacing--10` (a 10px fluid preset) for the gap between badges, which read as too loose for small pill-shaped tags sitting side by side. This tightens the gap to a fixed 2px.

## Testing

1. Open a post that has several tags/categories rendered with the Post Terms "Badge" style (e.g. in the single post header).
2. Confirm the badges sit 2px apart and still wrap correctly onto multiple lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)