### PR TITLE
Add empty-state messages to product collection and post query patterns

### DIFF
--- a/purple/patterns/posts-three-columns-center-aligned-heading.php
+++ b/purple/patterns/posts-three-columns-center-aligned-heading.php
@@ -27,7 +27,13 @@
 <!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"textColor":"theme-2"} /-->
 
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"0"}}},"fontSize":"x-large"} /-->
-<!-- /wp:post-template --></div>
+<!-- /wp:post-template -->
+
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<p class="has-text-align-center" style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'New posts will appear here soon.', 'purple' ); ?></p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
 <!-- /wp:query --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/purple/patterns/posts-three-columns-left-aligned-heading.php
+++ b/purple/patterns/posts-three-columns-left-aligned-heading.php
@@ -29,7 +29,13 @@
 <!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"textColor":"theme-2"} /-->
 
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"0"}}},"fontSize":"x-large"} /-->
-<!-- /wp:post-template --></div>
+<!-- /wp:post-template -->
+
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<p style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'New posts will appear here soon.', 'purple' ); ?></p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
 <!-- /wp:query --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-best-sellers-3-columns.php
+++ b/purple/patterns/woocommerce-best-sellers-3-columns.php
@@ -34,7 +34,13 @@
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"textAlign":"left","lineHeight":"1.18"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"0"}}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
 <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":"1.55"}}} /-->
-<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:woocommerce/product-collection-no-results -->
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<p style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'Our most popular products will appear here soon.', 'purple' ); ?></p>
+<!-- /wp:paragraph -->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/purple/patterns/woocommerce-best-sellers.php
+++ b/purple/patterns/woocommerce-best-sellers.php
@@ -23,6 +23,12 @@
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0","top":"var:preset|spacing|20"}},"typography":{"lineHeight":"1.18","textAlign":"left"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
 <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55","fontStyle":"normal"}}} /-->
-<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:woocommerce/product-collection-no-results -->
+<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<p class="has-text-align-center" style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'Our most popular products will appear here soon.', 'purple' ); ?></p>
+<!-- /wp:paragraph -->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-featured-products.php
+++ b/purple/patterns/woocommerce-featured-products.php
@@ -25,6 +25,12 @@
 
 <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55","fontStyle":"normal"}}} /-->
 
-<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:woocommerce/product-collection-no-results -->
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<p style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'We\'re curating our favorites. Check back soon.', 'purple' ); ?></p>
+<!-- /wp:paragraph -->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->

--- a/purple/patterns/woocommerce-new-arrivals.php
+++ b/purple/patterns/woocommerce-new-arrivals.php
@@ -23,6 +23,12 @@
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0","top":"var:preset|spacing|20"}},"typography":{"lineHeight":"1.18","textAlign":"left"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
 <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55","fontStyle":"normal"}}} /-->
-<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:woocommerce/product-collection-no-results -->
+<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<p class="has-text-align-center" style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'New products are on their way. Check back soon.', 'purple' ); ?></p>
+<!-- /wp:paragraph -->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
 <!-- /wp:woocommerce/product-collection --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
## What

Adds `product-collection-no-results` / `query-no-results` blocks with context-appropriate, i18n-wrapped copy to the storefront patterns that were missing a shopper-facing empty state:

| Pattern | Block | Copy |
|---|---|---|
| `woocommerce-new-arrivals` | product-collection-no-results | "New products are on their way. Check back soon." |
| `woocommerce-best-sellers` | product-collection-no-results | "Our most popular products will appear here soon." |
| `woocommerce-best-sellers-3-columns` | product-collection-no-results | "Our most popular products will appear here soon." |
| `woocommerce-featured-products` | product-collection-no-results | "We're curating our favorites. Check back soon." |
| `posts-three-columns-center-aligned-heading` | query-no-results | "New posts will appear here soon." |
| `posts-three-columns-left-aligned-heading` | query-no-results | "New posts will appear here soon." |

Paragraph alignment follows each section's heading (centered vs left).

## Why

Section headings in these patterns sit outside the product/post template, so an empty query rendered a dangling heading over blank space with no explanation. New Arrivals is especially prone to this in production: its collection only matches products published in the last 7 days, so it empties itself on any store that goes a quiet week.

Deliberate choices:
- **No filter links** — WooCommerce's default no-results copy ("try clearing any filters") targets the filterable catalog; these are storefront sections without filters. The catalog grid patterns already carry the default copy with working filter links.
- **Related/upsell patterns left alone** — "no results" under a "You may also like" heading is worse than rendering nothing, which is what an absent no-results block does (WooCommerce returns an empty string when the block has no content).
- **Posts patterns don't reuse `hidden-no-search-results`** — that copy ("No results were found using that search.") is search-specific; these are blog sections.

## Verification (live Local site, WP 7.0.1 / WC 10.9.4)

- `php -l` passes on all 6 files.
- All 6 patterns register with the no-results block and translated strings present in rendered content, and no raw PHP leaks into block markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)