### PR TITLE
Switch variation selector to color-configured chips and polish chip styles

### DIFF
--- a/purple/parts/variable-product-add-to-cart-with-options.html
+++ b/purple/parts/variable-product-add-to-cart-with-options.html
@@ -6,7 +6,9 @@
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
 			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-name /-->
 
-			<!-- wp:woocommerce/add-to-cart-with-options-variation-selector-attribute-options /-->
+			<!-- wp:woocommerce/product-filter-chips {"chipText":"theme-2","chipBackground":"theme-1","chipBorder":"theme-6","selectedChipText":"theme-1","selectedChipBackground":"theme-2","selectedChipBorder":"theme-2"} -->
+			<div class="wp-block-woocommerce-product-filter-chips wc-block-product-filter-chips has-chip-text-color has-chip-background-color has-chip-border-color has-selected-chip-text-color has-selected-chip-background-color has-selected-chip-border-color" style="--wc-product-filter-chips-text:var(--wp--preset--color--theme-2);--wc-product-filter-chips-background:var(--wp--preset--color--theme-1);--wc-product-filter-chips-border:var(--wp--preset--color--theme-6);--wc-product-filter-chips-selected-text:var(--wp--preset--color--theme-1);--wc-product-filter-chips-selected-background:var(--wp--preset--color--theme-2);--wc-product-filter-chips-selected-border:var(--wp--preset--color--theme-2)"></div>
+			<!-- /wp:woocommerce/product-filter-chips -->
 		</div>
 		<!-- /wp:group -->
 	</div>
@@ -14,9 +16,9 @@
 </div>
 <!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
 
-<!-- wp:woocommerce/add-to-cart-with-options-variation-description {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:woocommerce/add-to-cart-with-options-variation-description /-->
 
-<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
+<!-- wp:woocommerce/product-stock-indicator /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"stretch"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector /-->

--- a/purple/style.css
+++ b/purple/style.css
@@ -349,10 +349,6 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
    WooCommerce — Single product
    ========================================================================== */
 
-.wp-block-woocommerce-product-gallery-is-layout-flex {
-	gap: var(--wp--preset--spacing--50);
-}
-
 .wp-block-product-specifications-item__value p {
 	margin: 0
 }
@@ -380,6 +376,7 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	border: 0;
 	box-shadow: none;
 	flex: 1 1 auto;
+	font-weight: 400;
 	margin: 0;
 	min-width: 40px;
 	order: 2;
@@ -405,31 +402,23 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	order: 3;
 }
 
-:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pills) {
-	gap: var(--wp--preset--spacing--10);
-}
-
-:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill) {
-	border-color: var(--wp--preset--color--theme-4);
-	border-radius: 0;
-	font-size: var(--wp--preset--font-size--small);
-	font-weight: 400;
-	letter-spacing: 0.06em;
-	line-height: 1.142;
-	padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
-	text-transform: uppercase;
-}
-
-.woocommerce-page label.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
-	margin-bottom: 0;
-}
-
 .woocommerce-page label.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name {
 	margin-bottom: 0;
 }
 
-:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked)) {
-	background-color: var(--wp--preset--color--theme-2);
+:where(.wc-block-product-filter-chips__items) {
+	gap: var(--wp--preset--spacing--10);
+}
+
+/* Product filter chips expose no typography UI and WooCommerce hardcodes .8em. */
+.wc-block-product-filter-chips__item {
+	border-radius: 0;
+	color: var(--wp--preset--color--theme-2);
+	font-size: var(--wp--preset--font-size--small);
+	letter-spacing: 0.06em;
+	line-height: 1.28;
+	padding: 0.625rem 1.25rem;
+	text-transform: uppercase;
 }
 
 .wp-block-accordion-heading__toggle:hover .wp-block-accordion-heading__toggle-title {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -528,7 +528,7 @@
 			},
 			"woocommerce/product-gallery": {
 				"spacing": {
-					"blockGap": "var(--wp--preset--spacing--50)"
+					"blockGap": "var(--wp--preset--spacing--10)"
 				}
 			},
 			"woocommerce/product-gallery-large-image-next-previous": {


### PR DESCRIPTION
## What

1. **Variation selector: pills → chips** (`parts/variable-product-add-to-cart-with-options.html`). The `attribute-options` (pills) block is replaced with `woocommerce/product-filter-chips`, colored entirely through the block's own color attributes using palette slugs (`theme-1`/`theme-2`/`theme-6`) — including the **selected state** (inverted: theme-2 background, theme-1 text), which plain CSS could not reach cleanly. Stale `custom*` hex fallbacks from the editor export were dropped in favor of presets only. Also removes the now-redundant margins on the variation description and stock indicator.

2. **Chip typography & spacing** (`style.css`): the chips block exposes no typography UI and WooCommerce hardcodes `font-size: .8em`, so the theme styles the items directly — small font size, `0.06em` letter spacing, `1.28` line height, `0.625rem 1.25rem` padding, square corners, uppercase — plus a wider gap between chips (spacing-10 over WooCommerce's 4px).

3. **Quantity input weight** (`style.css`): WooCommerce's add-to-cart-with-options styles set `font-weight: 600` on the qty input (via zero-specificity `:where()` rules); normalized to 400 in the existing quantity-selector rule.

4. **Dead pills CSS removed** (`style.css`): with the pills block gone from the only part that used it, its four rules styled unreachable markup. The `label...attribute-name` rule stays — that block is still in use.

5. **Product gallery gap** (`theme.json`): `blockGap` spacing-50 → spacing-10, tightening the space between the gallery image and thumbnails.

## Verification (live Local site, WP 7.0.1 / WC 10.9.4)

- Variable product page (Hoodie) renders both attributes as chips — 7 chips across 2 groups, color attributes active (`has-chip-text-color` etc.), zero pills markup remaining.
- Chip typography rules confirmed in the served stylesheet; the qty input rule outranks WooCommerce's `:where()` by definition.
- Page returns 200 after all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)