### PR TITLE
Point Theme URI at the WordPress.com theme page

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Purple
-Theme URI: https://github.com/woocommerce/woo-themes/tree/trunk/purple
+Theme URI: https://wordpress.com/themes/purple
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Purple is the new WooCommerce starter theme, fully built with blocks and ready for modern commerce. Designed with apparel stores in mind, it features clean styles and a simplistic color palette that adapts to any brand. Packed with commerce-ready templates and curated patterns, Purple offers a versatile foundation for launching your next online store with ease and precision.


### PR DESCRIPTION
## Changes

- Update the `Theme URI` header in `purple/style.css` from the GitHub tree URL to https://wordpress.com/themes/purple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)