### PR TITLE
Add a hover state to the Contrast button style

### DIFF
--- a/purple/styles/block/button-1.json
+++ b/purple/styles/block/button-1.json
@@ -10,6 +10,7 @@
 		"color": {
 			"background": "var(--wp--preset--color--theme-1)",
 			"text": "var(--wp--preset--color--theme-2)"
-		}
+		},
+		"css": ".wp-block-button__link:not(.has-background):hover { background-color: color-mix(in srgb, var(--wp--preset--color--theme-1) 95%, var(--wp--preset--color--theme-2)); }"
 	}
 }


### PR DESCRIPTION
## Changes

- Add a hover rule to the Contrast button style variation (`styles/block/button-1.json`), which previously had no visual feedback: the white background dims 5% toward `theme-2` on hover via `color-mix`.
- Uses the same `css`-property mechanism and 5% intensity as the outline style's hover in `theme.json`, with the `:not(.has-background)` guard so user-selected colors still win.

## Testing

Hover a Contrast-style button (e.g. on a cover/hero section) — the background should dim slightly, like the default and outline styles do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)