### PR TITLE
Rename the Contrast button style slug to button-contrast

### DIFF
--- a/purple/patterns/about-category-collection.php
+++ b/purple/patterns/about-category-collection.php
@@ -33,8 +33,8 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Cardigans', 'purple');?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Cardigans', 'purple');?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -49,8 +49,8 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Sweaters', 'purple');?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Sweaters', 'purple');?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -65,8 +65,8 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Socks', 'purple');?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Socks', 'purple');?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -81,8 +81,8 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Beanies', 'purple');?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e('Shop Beanies', 'purple');?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>

--- a/purple/patterns/categories-on-three-columns.php
+++ b/purple/patterns/categories-on-three-columns.php
@@ -14,8 +14,8 @@
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/sweaters.webp","alt":"<?php esc_attr_e( 'Stack of folded colourful knit sweaters.', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background size-full" alt="<?php esc_attr_e( 'Stack of folded colourful knit sweaters.', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/sweaters.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop Cardigans', 'purple' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop Cardigans', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>
@@ -24,8 +24,8 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pink-sweater-man-cropped-2.webp","alt":"<?php esc_attr_e( 'Model in a bright pink knit sweater.', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"focalPoint":{"x":0.54,"y":0.49},"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background size-full" alt="<?php esc_attr_e( 'Model in a bright pink knit sweater.', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/pink-sweater-man-cropped-2.webp" style="object-position:54% 49%" data-object-fit="cover" data-object-position="54% 49%"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop Sweaters', 'purple' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop Sweaters', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>
@@ -34,8 +34,8 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/orange-sweater-woman-cropped-2.webp","alt":"<?php esc_attr_e( 'Female model wearing a colourful knit sweater in a colourful background', 'purple' ); ?>","dimRatio":0,"overlayColor":"theme-2","isUserOverlayColor":true,"contentPosition":"bottom center","isDark":false,"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"dimensions":{"aspectRatio":"3/4"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-cover is-light has-custom-content-position is-position-bottom-center" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background size-full" alt="<?php esc_attr_e( 'Female model wearing a colourful knit sweater in a colourful background', 'purple' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/orange-sweater-woman-cropped-2.webp" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-theme-2-background-color has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop Accessories', 'purple' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop Accessories', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>

--- a/purple/patterns/hero-with-text-and-two-buttons.php
+++ b/purple/patterns/hero-with-text-and-two-buttons.php
@@ -25,8 +25,8 @@
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop new arrivals', 'purple' ); ?></a></div>
 <!-- /wp:button -->
 
-<!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop all products', 'purple' ); ?></a></div>
+<!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop all products', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div></div>

--- a/purple/patterns/two-columns-highlights-sections.php
+++ b/purple/patterns/two-columns-highlights-sections.php
@@ -22,8 +22,8 @@
 <!-- /wp:heading -->
 
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'purple' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>
@@ -40,8 +40,8 @@
 <!-- /wp:heading -->
 
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-1"} -->
-<div class="wp-block-button is-style-button-1"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'purple' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-button-contrast"} -->
+<div class="wp-block-button is-style-button-contrast"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>

--- a/purple/styles/block/button-contrast.json
+++ b/purple/styles/block/button-contrast.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 3,
-	"slug": "button-1",
+	"slug": "button-contrast",
 	"title": "Contrast",
 	"blockTypes": [
 		"core/button"


### PR DESCRIPTION
## Changes

- Rename `styles/block/button-1.json` to `styles/block/button-contrast.json` and change its slug from `button-1` to `button-contrast`, so the generated class is `is-style-button-contrast` instead of the opaque `is-style-button-1`.
- Update all 10 button references across the 4 patterns that use the style: `hero-with-text-and-two-buttons`, `categories-on-three-columns`, `two-columns-highlights-sections`, `about-category-collection`.

## Note

⚠️ Saved content created from these patterns (e.g. demo site pages) has `is-style-button-1` flattened into stored markup and will lose the Contrast style — re-apply the style in the editor after this lands. Pre-release, so no external compatibility impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)