### PR TITLE
Underline links in product summary and description

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -372,6 +372,17 @@ textarea {
    WooCommerce — Single product
    ========================================================================== */
 
+/* Underline links in the product summary and description; remove on hover to match .underline-link. */
+.wc-block-components-product-summary a,
+.wc-block-product-description a {
+	text-decoration: underline;
+}
+
+.wc-block-components-product-summary a:hover,
+.wc-block-product-description a:hover {
+	text-decoration: none;
+}
+
 .wp-block-product-specifications-item__value p {
 	margin: 0
 }


### PR DESCRIPTION
## Changes

- Underline links inside `wc-block-components-product-summary` and `wc-block-product-description`, removing the underline on hover — the same interaction as the theme's `.underline-link` utility.
- Added to the "WooCommerce — Single product" section of `style.css`.

## Testing

On a single product page, links within the product summary (short description) and the product description should render underlined and lose the underline on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)