### PR TITLE
Reduce pagination top margin in product grid patterns

### DIFF
--- a/purple/patterns/page-new-arrivals.php
+++ b/purple/patterns/page-new-arrivals.php
@@ -129,8 +129,8 @@
 <!-- /wp:group -->
 <!-- /wp:woocommerce/product-template -->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"<?php esc_html_e('Previous', 'purple');?>"} /-->
 
 <!-- wp:query-pagination-numbers /-->

--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -140,8 +140,8 @@
 <!-- /wp:group -->
 <!-- /wp:woocommerce/product-template -->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"<?php esc_html_e('Previous', 'purple');?>"} /-->
 
 <!-- wp:query-pagination-numbers /-->

--- a/purple/patterns/product-grid-without-filters.php
+++ b/purple/patterns/product-grid-without-filters.php
@@ -36,8 +36,8 @@
 <!-- /wp:group -->
 <!-- /wp:woocommerce/product-template -->
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:0"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"<?php esc_html_e('Previous', 'purple');?>"} /-->
 
 <!-- wp:query-pagination-numbers /-->


### PR DESCRIPTION
## Changes

- Reduce the top margin on the pagination group from `spacing|70` to `spacing|30` in all three product collection patterns: `product-grid-with-filters`, `product-grid-without-filters`, and `page-new-arrivals`.
- This tightens the gap between the last product row and the Previous / numbers / Next pagination on the shop, search results, attribute taxonomy, and New Arrivals views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)