### PR TITLE
Fix spacing presets collapsing in Firefox

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -76,7 +76,8 @@
 			]
 		},
 		"custom": {
-			"spacing-unit": "10"
+			"spacing-unit": "10",
+			"wide-size": "1340"
 		},
 		"layout": {
 			"contentSize": "645px",
@@ -90,37 +91,37 @@
 			"spacingSizes": [
 				{
 					"name": "2X-Small",
-					"size": "clamp(10px, calc(var(--wp--custom--spacing-unit) * 1 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 1 * 1px))",
+					"size": "clamp(10px, calc(var(--wp--custom--spacing-unit) * 1 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 1 * 1px))",
 					"slug": "10"
 				},
 				{
 					"name": "X-Small",
-					"size": "clamp(10px, calc(var(--wp--custom--spacing-unit) * 2 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 2 * 1px))",
+					"size": "clamp(10px, calc(var(--wp--custom--spacing-unit) * 2 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 2 * 1px))",
 					"slug": "20"
 				},
 				{
 					"name": "Small",
-					"size": "clamp(20px, calc(var(--wp--custom--spacing-unit) * 3 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 3 * 1px))",
+					"size": "clamp(20px, calc(var(--wp--custom--spacing-unit) * 3 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 3 * 1px))",
 					"slug": "30"
 				},
 				{
 					"name": "Regular",
-					"size": "clamp(20px, calc(var(--wp--custom--spacing-unit) * 5 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 5 * 1px))",
+					"size": "clamp(20px, calc(var(--wp--custom--spacing-unit) * 5 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 5 * 1px))",
 					"slug": "50"
 				},
 				{
 					"name": "Large",
-					"size": "clamp(50px, calc(var(--wp--custom--spacing-unit) * 7 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 7 * 1px))",
+					"size": "clamp(50px, calc(var(--wp--custom--spacing-unit) * 7 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 7 * 1px))",
 					"slug": "70"
 				},
 				{
 					"name": "Extra Large",
-					"size": "clamp(50px, calc(var(--wp--custom--spacing-unit) * 9 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 9 * 1px))",
+					"size": "clamp(50px, calc(var(--wp--custom--spacing-unit) * 9 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 9 * 1px))",
 					"slug": "90"
 				},
 				{
 					"name": "2X Large",
-					"size": "clamp(70px, calc(var(--wp--custom--spacing-unit) * 14 * 1px * 100vw / var(--wp--style--global--wide-size)), calc(var(--wp--custom--spacing-unit) * 14 * 1px))",
+					"size": "clamp(70px, calc(var(--wp--custom--spacing-unit) * 14 * 100vw / var(--wp--custom--wide-size)), calc(var(--wp--custom--spacing-unit) * 14 * 1px))",
 					"slug": "140"
 				}
 			]


### PR DESCRIPTION
## Problem

All seven fluid `spacingSizes` presets computed their preferred value as

```
calc(var(--wp--custom--spacing-unit) * N * 1px * 100vw / var(--wp--style--global--wide-size))
```

`1px * 100vw` (length × length) divided by `1340px` (÷ length) is [CSS typed arithmetic](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Values_and_units/Using_typed_arithmetic) from css-values-4, supported only in Chrome 140+ and Safari 18.2+. **Firefox doesn't support it**, so the whole `clamp()` was invalid at computed-value time and every spacing preset collapsed — margins, paddings, and gaps across the theme.

## Fix

Add a unitless `"wide-size": "1340"` to `settings.custom` and rewrite the formula as

```
calc(var(--wp--custom--spacing-unit) * N * 100vw / var(--wp--custom--wide-size))
```

`number × 100vw ÷ number` is classic calc, supported everywhere, and computes the same values as before in browsers where the old formula worked.

⚠️ Maintenance note: theme.json can't carry comments, so flagging it here — `settings.custom.wide-size` (1340) and `settings.layout.wideSize` (1340px) are two copies of the same number and must change together.

## Testing

Verified in Firefox: spacing presets (section paddings, grid gaps) now render identically to Chrome/Safari instead of collapsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)