### PR TITLE
Purple: Reduce filter accordion spacer height to spacing preset 10

### DIFF
--- a/purple/patterns/page-new-arrivals.php
+++ b/purple/patterns/page-new-arrivals.php
@@ -38,8 +38,8 @@
 <!-- /wp:woocommerce/product-filter-price-slider --></div>
 <!-- /wp:woocommerce/product-filter-price -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:accordion-panel --></div>
 <!-- /wp:accordion-item -->
@@ -55,8 +55,8 @@
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:woocommerce/product-filter-rating --></div>
 <!-- /wp:accordion-panel --></div>
@@ -73,8 +73,8 @@
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:woocommerce/product-filter-attribute --></div>
 <!-- /wp:accordion-panel --></div>
@@ -92,8 +92,8 @@
 <!-- /wp:woocommerce/product-filter-checkbox-list --></div>
 <!-- /wp:woocommerce/product-filter-status -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:accordion-panel --></div>
 <!-- /wp:accordion-item --></div>

--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -49,8 +49,8 @@
 <!-- /wp:woocommerce/product-filter-price-slider --></div>
 <!-- /wp:woocommerce/product-filter-price -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:accordion-panel --></div>
 <!-- /wp:accordion-item -->
@@ -66,8 +66,8 @@
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:woocommerce/product-filter-rating --></div>
 <!-- /wp:accordion-panel --></div>
@@ -84,8 +84,8 @@
 <div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
 <!-- /wp:woocommerce/product-filter-checkbox-list -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:woocommerce/product-filter-attribute --></div>
 <!-- /wp:accordion-panel --></div>
@@ -103,8 +103,8 @@
 <!-- /wp:woocommerce/product-filter-checkbox-list --></div>
 <!-- /wp:woocommerce/product-filter-status -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|10"} -->
+<div style="height:var(--wp--preset--spacing--10)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:accordion-panel --></div>
 <!-- /wp:accordion-item --></div>


### PR DESCRIPTION
## Changes

Reduces the height of the spacer at the bottom of each product filter accordion panel (Price, Rating, Color, Status) from the `20` spacing preset to the `10` preset.

The filter sidebar accordion is byte-for-byte identical in the two patterns that use it, so both are updated to stay in sync:

- `patterns/product-grid-with-filters.php`
- `patterns/page-new-arrivals.php`

## Testing

1. Activate Purple and visit the Shop page (Product Catalog template), or insert the New arrivals pattern on a page.
2. Expand each filter accordion panel.
3. Confirm the gap below each filter control (before the panel's bottom border) is smaller, using the `10` spacing preset.

Note: if the Product Catalog template has saved customizations, reset it in the Site Editor first, otherwise the flattened copy keeps the old spacer value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)