### PR TITLE
Purple: Remove unregistered Fraunces heading font from Crimson Pro variation

### DIFF
--- a/purple/styles/typography/crimson-pro.json
+++ b/purple/styles/typography/crimson-pro.json
@@ -126,11 +126,6 @@
 					"fontStyle": "normal",
 					"fontWeight": "500"
 				}
-			},
-			"heading": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--fraunces)"
-				}
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Fixes #336

## Changes

The Crimson Pro typography variation assigned `var(--wp--preset--font-family--fraunces)` to `elements.heading`, but Fraunces is not registered in that variation or in the base theme. The variable was undefined, making the declaration invalid at computed-value time, so headings already fell back to inheriting Crimson Pro from the body.

This removes the `heading` element entry entirely rather than pointing it at the Crimson Pro preset:

- The base `theme.json` sets no heading `fontFamily`, so headings inherit the body font, which is Crimson Pro in this variation.
- This matches the other single-font variations (`figtree.json`, `suse-mono.json`), which also rely on inheritance instead of declaring a redundant heading font.

No visual change; this is a cleanup of a broken reference.

## Testing

1. Activate Purple and apply the Crimson Pro style variation (Site Editor > Styles > Typography).
2. Confirm headings and body text both render in Crimson Pro, same as before.
3. Confirm the generated global styles CSS no longer references `--wp--preset--font-family--fraunces`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)