### PR TITLE
Purple: Add four color style variations

### DIFF
--- a/purple/styles/colors/autumn.json
+++ b/purple/styles/colors/autumn.json
@@ -1,0 +1,45 @@
+{
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"color": "#301f12",
+					"name": "Color 1",
+					"slug": "theme-1"
+				},
+				{
+					"color": "#e5e5e5",
+					"name": "Color 2",
+					"slug": "theme-2"
+				},
+				{
+					"color": "#343d2a",
+					"name": "Color 3",
+					"slug": "theme-3"
+				},
+				{
+					"color": "#a4a4a4",
+					"name": "Color 4",
+					"slug": "theme-4"
+				},
+				{
+					"color": "#281a0f",
+					"name": "Color 5",
+					"slug": "theme-5"
+				},
+				{
+					"color": "rgba(229, 229, 229, 0.2)",
+					"name": "Color 6",
+					"slug": "theme-6"
+				},
+				{
+					"color": "#e2b63e",
+					"name": "Color 7",
+					"slug": "theme-7"
+				}
+			]
+		}
+	},
+	"version": 3,
+	"title": "Autumn"
+}

--- a/purple/styles/colors/electric-kiwi.json
+++ b/purple/styles/colors/electric-kiwi.json
@@ -1,0 +1,45 @@
+{
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"color": "#262623",
+					"name": "Color 1",
+					"slug": "theme-1"
+				},
+				{
+					"color": "#f8f9f7",
+					"name": "Color 2",
+					"slug": "theme-2"
+				},
+				{
+					"color": "#1a1b19",
+					"name": "Color 3",
+					"slug": "theme-3"
+				},
+				{
+					"color": "#969795",
+					"name": "Color 4",
+					"slug": "theme-4"
+				},
+				{
+					"color": "#c2ff00",
+					"name": "Color 5",
+					"slug": "theme-5"
+				},
+				{
+					"color": "rgba(248, 249, 247, 0.2)",
+					"name": "Color 6",
+					"slug": "theme-6"
+				},
+				{
+					"color": "#c2ff00",
+					"name": "Color 7",
+					"slug": "theme-7"
+				}
+			]
+		}
+	},
+	"version": 3,
+	"title": "Electric Kiwi"
+}

--- a/purple/styles/colors/matcha.json
+++ b/purple/styles/colors/matcha.json
@@ -1,0 +1,45 @@
+{
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"color": "#f0efed",
+					"name": "Color 1",
+					"slug": "theme-1"
+				},
+				{
+					"color": "#000000",
+					"name": "Color 2",
+					"slug": "theme-2"
+				},
+				{
+					"color": "#56543b",
+					"name": "Color 3",
+					"slug": "theme-3"
+				},
+				{
+					"color": "#373330",
+					"name": "Color 4",
+					"slug": "theme-4"
+				},
+				{
+					"color": "#f4eecc",
+					"name": "Color 5",
+					"slug": "theme-5"
+				},
+				{
+					"color": "rgba(17, 17, 17, 0.2)",
+					"name": "Color 6",
+					"slug": "theme-6"
+				},
+				{
+					"color": "#687300",
+					"name": "Color 7",
+					"slug": "theme-7"
+				}
+			]
+		}
+	},
+	"version": 3,
+	"title": "Matcha"
+}

--- a/purple/styles/colors/vibrant-ice.json
+++ b/purple/styles/colors/vibrant-ice.json
@@ -1,0 +1,45 @@
+{
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"color": "#232121",
+					"name": "Color 1",
+					"slug": "theme-1"
+				},
+				{
+					"color": "#e5e5e5",
+					"name": "Color 2",
+					"slug": "theme-2"
+				},
+				{
+					"color": "#173841",
+					"name": "Color 3",
+					"slug": "theme-3"
+				},
+				{
+					"color": "#9e9e9e",
+					"name": "Color 4",
+					"slug": "theme-4"
+				},
+				{
+					"color": "#2e2e2e",
+					"name": "Color 5",
+					"slug": "theme-5"
+				},
+				{
+					"color": "rgba(229, 229, 229, 0.2)",
+					"name": "Color 6",
+					"slug": "theme-6"
+				},
+				{
+					"color": "#14e9f9",
+					"name": "Color 7",
+					"slug": "theme-7"
+				}
+			]
+		}
+	},
+	"version": 3,
+	"title": "Vibrant Ice"
+}


### PR DESCRIPTION
Fixes #351 ([WOOTHME-416](https://linear.app/a8c/issue/WOOTHME-416/add-additional-color-palettes-4-additional-10-total))

## Changes

Adds the four new color palettes designed by @beafialho in the [Purple Figma file](https://www.figma.com/design/Gum9XNWccPKfkVRFk1Whsp/Purple--Woo-Starter-Theme-?node-id=6537-2725), bringing the theme to 10 palettes total (default + 9 variations):

- `styles/colors/vibrant-ice.json` (dark, cyan accent)
- `styles/colors/autumn.json` (dark brown, gold accent)
- `styles/colors/matcha.json` (light, olive accent)
- `styles/colors/electric-kiwi.json` (dark, neon green accent)

Notes:

- The three dark schemes use their light theme-2 color at 20% opacity for theme-6 (borders), matching the convention of the existing light palettes (theme-2 at 20%) so borders stay visible on dark backgrounds. Confirmed with Bea.
- Electric Kiwi intentionally uses `#c2ff00` for both theme-5 and theme-7 to include some vibrant sections. Also confirmed with Bea.

## Testing

1. Activate Purple and open Site Editor > Styles > Browse styles.
2. Confirm the four new variations appear and apply correctly.
3. Spot-check a dark variation (e.g. Vibrant Ice): accordion and table borders should be subtly visible, not invisible black-on-dark.
4. Spot-check patterns using theme-5 section tints (e.g. Store features, Testimonials) in each new variation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)