### PR TITLE
Purple: Fix button legibility across dark color schemes

### DIFF
--- a/purple/styles/colors/autumn.json
+++ b/purple/styles/colors/autumn.json
@@ -58,6 +58,59 @@
 			]
 		}
 	},
+	"styles": {
+		"blocks": {
+			"core/column": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			},
+			"core/columns": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			},
+			"core/group": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-2)"
+				}
+			}
+		}
+	},
 	"version": 3,
 	"title": "Autumn"
 }

--- a/purple/styles/colors/electric-kiwi.json
+++ b/purple/styles/colors/electric-kiwi.json
@@ -58,6 +58,59 @@
 			]
 		}
 	},
+	"styles": {
+		"blocks": {
+			"core/column": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			},
+			"core/columns": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			},
+			"core/group": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-2)"
+				}
+			}
+		}
+	},
 	"version": 3,
 	"title": "Electric Kiwi"
 }

--- a/purple/styles/colors/vibrant-ice.json
+++ b/purple/styles/colors/vibrant-ice.json
@@ -58,6 +58,59 @@
 			]
 		}
 	},
+	"styles": {
+		"blocks": {
+			"core/column": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			},
+			"core/columns": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			},
+			"core/group": {
+				"variations": {
+					"section-2": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					},
+					"section-3": {
+						"color": {
+							"text": "var(--wp--preset--color--theme-2)"
+						}
+					}
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"text": "var(--wp--preset--color--theme-2)"
+				}
+			}
+		}
+	},
 	"version": 3,
 	"title": "Vibrant Ice"
 }

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -244,9 +244,6 @@
 							"color": "currentColor",
 							"width": "1px"
 						},
-						"color": {
-							"text": "var(--wp--preset--color--theme-2)"
-						},
 						"css": ".wp-block-button__link:not(.has-background):hover {background-color:color-mix(in srgb, currentColor 5%, transparent);}",
 						"spacing": {
 							"padding": {


### PR DESCRIPTION
Follow-up to #359, #360, and #361: buttons were the remaining element breaking under the dark color schemes.

## Fixes

1. **Default buttons**: `theme-3` background + `theme-1` text are both dark slots in the dark schemes (Autumn rendered `#301f12` text on `#343d2a`). The three dark variations now override `styles.elements.button` text to `theme-2`, keeping the accent background and switching the label to the scheme's ink. Light schemes untouched.

2. **Outline style**: `theme.json` pinned the outline variation's text to `theme-2`, which outranks core's follow-the-context rule and the section styles. Result: invisible on Section Style 1 bands (background *is* theme-2) in every scheme, dark-on-blue and dark-on-gray on Styles 2/3 in light schemes. The pin is removed; outline buttons now inherit the surrounding text color as core intends (band text inside sections, white on covers, body text elsewhere). The 1px `currentColor` border, hover, and padding stay.

3. **Section Styles 2/3 text in dark schemes**: Style 2 pairs `theme-5` text with a `theme-3` band and Style 3 `theme-1` with `theme-4`; under dark palettes those render dark-on-dark (visible on headings, not just buttons). The dark variations override both section styles' text to `theme-2` across `core/group`, `core/columns`, and `core/column`. Bea may want to tune Style 3's mid-gray band pairing in review; `theme-2` was the working default we shipped.

Deliberately unchanged: the section styles' button overrides (`theme-1` background, `theme-2` text) are a background/ink pair that flips coherently and stays readable in all 10 schemes.

## Testing

1. Site Editor > Styles: flip between a light scheme and Autumn / Vibrant Ice / Electric Kiwi.
2. Place Default, Outline, and Contrast buttons on a plain page, inside Section Style 1/2/3 groups, and on a cover.
3. All three styles should be legible in every context in every scheme; in particular Outline on a Style 1 band (was invisible) and Default buttons in dark schemes (was dark-on-dark).
4. Check Section Style 2/3 headings and body text under a dark scheme: now light ink on the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)