### PR TITLE
Purple: Apply duotone to brand logo images in testimonial patterns

### DIFF
--- a/purple/patterns/testimonial-with-logo.php
+++ b/purple/patterns/testimonial-with-logo.php
@@ -18,7 +18,7 @@
 <p class="has-text-align-center has-theme-2-color has-text-color has-link-color has-large-font-size" style="margin-top:var(--wp--preset--spacing--50)"><?php esc_html_e('“With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.”', 'purple');?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"130px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} -->
+<!-- wp:image {"width":"130px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"color":{"duotone":"var:preset|duotone|duotone-2"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} -->
 <figure class="wp-block-image aligncenter size-full is-resized" style="margin-top:var(--wp--preset--spacing--30)"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/logo-3.webp" alt="<?php esc_attr_e('Brand logo', 'purple');?>" style="width:130px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/purple/patterns/testimonials-in-two-columns.php
+++ b/purple/patterns/testimonials-in-two-columns.php
@@ -21,7 +21,7 @@
 <p class="has-text-align-center has-theme-2-color has-text-color has-link-color"><?php esc_html_e( '“With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.”', 'purple' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"163px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<!-- wp:image {"width":"163px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"color":{"duotone":"var:preset|duotone|duotone-2"},"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
 <figure class="wp-block-image aligncenter size-full is-resized" style="margin-top:var(--wp--preset--spacing--50)"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/logo-1.webp" alt="<?php esc_attr_e( 'Brand logo', 'purple' ); ?>" style="width:163px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
@@ -31,7 +31,7 @@
 <p class="has-text-align-center has-theme-2-color has-text-color has-link-color"><?php esc_html_e( '“With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.”', 'purple' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"width":"135px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<!-- wp:image {"width":"135px","sizeSlug":"full","linkDestination":"none","align":"center","style":{"color":{"duotone":"var:preset|duotone|duotone-2"},"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
 <figure class="wp-block-image aligncenter size-full is-resized" style="margin-top:var(--wp--preset--spacing--50)"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/logo-2.webp" alt="<?php esc_attr_e( 'Brand logo', 'purple' ); ?>" style="width:135px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>


### PR DESCRIPTION
Follow-up to #360 ([WOOTHME-416](https://linear.app/a8c/issue/WOOTHME-416/add-additional-color-palettes-4-additional-10-total)): the brand logo images were still rendering their original dark artwork in every color scheme, near-invisible on the dark ones.

## Changes

Adds `duotone-2` (ink on tint) to the three brand logo images, the same preset the store-features icons use:

- `patterns/testimonial-with-logo.php`: `logo-3.webp`
- `patterns/testimonials-in-two-columns.php`: `logo-1.webp`, `logo-2.webp`

Both patterns are `theme-5` tinted sections, so `duotone-2` is the matching preset, and the per-variation duotone overrides from #360 make the logos follow each scheme's ink automatically: dark on light tints, light on dark schemes. Attribute-only change; the duotone class is applied at render time.

## Testing

1. View the two testimonial patterns (e.g. on a page) under a light scheme: logos look as before, in the ink color.
2. Switch to Autumn / Vibrant Ice / Electric Kiwi: logos render light instead of disappearing into the dark tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)