### PR TITLE
Purple: Update Electric Kiwi palette to revised design

### DIFF
--- a/purple/styles/colors/electric-kiwi.json
+++ b/purple/styles/colors/electric-kiwi.json
@@ -23,7 +23,7 @@
 					"slug": "theme-4"
 				},
 				{
-					"color": "#c2ff00",
+					"color": "#314a0d",
 					"name": "Color 5",
 					"slug": "theme-5"
 				},
@@ -33,7 +33,7 @@
 					"slug": "theme-6"
 				},
 				{
-					"color": "#c2ff00",
+					"color": "#a3f107",
 					"name": "Color 7",
 					"slug": "theme-7"
 				}
@@ -49,8 +49,8 @@
 				},
 				{
 					"colors": [
-						"#262623",
-						"#c2ff00"
+						"#f8f9f7",
+						"#314a0d"
 					],
 					"name": "Duotone 2",
 					"slug": "duotone-2"


### PR DESCRIPTION
Part of [WOOTHME-416](https://linear.app/a8c/issue/WOOTHME-416/add-additional-color-palettes-4-additional-10-total); follow-up to #359/#360.

## Changes

@beafialho revised the Electric Kiwi variation in Figma to resolve its theme-5/theme-7 neon duplication:

- `theme-5`: `#c2ff00` -> `#314a0d` (dark olive tint; tint sections no longer neon)
- `theme-7`: `#c2ff00` -> `#a3f107` (adjusted neon accent)
- `duotone-2`: the Electric Kiwi-specific dark-ink exception from #360 is removed; with theme-5 now a dark tint it uses the standard formula, `#f8f9f7` ink on the `#314a0d` tint, consistent with Vibrant Ice and Autumn

All other values are unchanged in the revised design. Slot-based dark-scheme overrides (button text, Section Style 2/3 text) follow the palette automatically.

## Testing

1. Apply Electric Kiwi in Site Editor > Styles (re-apply if it was saved before, since applying snapshots values).
2. Tint sections (Store features, Testimonials) render dark olive with light icons/logos.
3. Accent elements (Sale badges, prices, default button backgrounds stay theme-3) show the new `#a3f107` neon.
4. No element renders the old `#c2ff00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)