### PR TITLE
Purple: Section text and outline button fixes for dark schemes

### DIFF
--- a/purple/patterns/about-left-aligned-image-description-button.php
+++ b/purple/patterns/about-left-aligned-image-description-button.php
@@ -30,8 +30,8 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"textColor":"theme-1","className":"is-style-outline","style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-1"}}}}} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-theme-1-color has-text-color has-link-color wp-element-button"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></div>
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>

--- a/purple/style.css
+++ b/purple/style.css
@@ -34,6 +34,17 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
+/* Outline buttons default to the ink color via this custom property
+ * (see the outline variation css in theme.json). Inside section styles
+ * and covers the local text color already accounts for the surface, so
+ * resolve to currentColor there and let the context decide. */
+.is-style-section-1,
+.is-style-section-2,
+.is-style-section-3,
+.wp-block-cover {
+	--wp--custom--outline-button-color: currentColor;
+}
+
 /*
  * Tighten margin when a heading follows another heading in post content.
  * The extra top-margin in theme.json signals a section break above; when

--- a/purple/styles/colors/autumn.json
+++ b/purple/styles/colors/autumn.json
@@ -65,11 +65,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}
@@ -79,11 +103,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}
@@ -93,11 +141,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}

--- a/purple/styles/colors/electric-kiwi.json
+++ b/purple/styles/colors/electric-kiwi.json
@@ -65,11 +65,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}
@@ -79,11 +103,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}
@@ -93,11 +141,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}

--- a/purple/styles/colors/vibrant-ice.json
+++ b/purple/styles/colors/vibrant-ice.json
@@ -65,11 +65,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}
@@ -79,11 +103,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}
@@ -93,11 +141,35 @@
 					"section-2": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					},
 					"section-3": {
 						"color": {
 							"text": "var(--wp--preset--color--theme-2)"
+						},
+						"elements": {
+							"heading": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							},
+							"link": {
+								"color": {
+									"text": "var(--wp--preset--color--theme-2)"
+								}
+							}
 						}
 					}
 				}

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -76,6 +76,7 @@
 			]
 		},
 		"custom": {
+			"outline-button-color": "var(--wp--preset--color--theme-2)",
 			"spacing-unit": "10",
 			"wide-size": "1340"
 		},
@@ -217,7 +218,7 @@
 					}
 				},
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--medium)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "400"
 				}
 			},
@@ -244,7 +245,7 @@
 							"color": "currentColor",
 							"width": "1px"
 						},
-						"css": ".wp-block-button__link:not(.has-background):hover {background-color:color-mix(in srgb, currentColor 5%, transparent);}",
+						"css": ".wp-block-button__link:not(.has-background):hover {background-color:color-mix(in srgb, currentColor 5%, transparent);}&.wp-block-button__link:not(.has-text-color) {color:var(--wp--custom--outline-button-color);}",
 						"spacing": {
 							"padding": {
 								"bottom": "calc(0.75em - 1px)",
@@ -307,7 +308,7 @@
 					}
 				}
 			},
-			"core/comment-reply-link": {	
+			"core/comment-reply-link": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": "1.71"
@@ -427,7 +428,7 @@
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontStyle": "normal",
 					"fontWeight": "700",
-					"letterSpacing":"0.09em",
+					"letterSpacing": "0.09em",
 					"lineHeight": "1.18",
 					"textTransform": "uppercase"
 				}
@@ -449,18 +450,18 @@
 					"blockGap": "0"
 				}
 			},
-			"woocommerce/add-to-cart-with-options-variation-selector-attribute-name" : {
+			"woocommerce/add-to-cart-with-options-variation-selector-attribute-name": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-4)"
 				},
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": "1.71"
 				}
 			},
 			"woocommerce/breadcrumbs": {
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": "1.71"
 				}
 			},
@@ -529,32 +530,32 @@
 					"text": "var(--wp--preset--color--theme-2)"
 				}
 			},
-			"woocommerce/product-reviews" : {
+			"woocommerce/product-reviews": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-2)"
 				}
 			},
-			"woocommerce/product-review-author-name" : {
+			"woocommerce/product-review-author-name": {
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "700",
 					"lineHeight": "1.71"
 				}
 			},
-			"woocommerce/product-review-date" : {
+			"woocommerce/product-review-date": {
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": "1.71"
 				}
 			},
-			"woocommerce/product-review-content" : {
+			"woocommerce/product-review-content": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-4)"
 				}
 			},
 			"woocommerce/product-sale-badge": {
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "400",
 					"lineHeight": "1.71",
 					"textTransform": "none"
@@ -570,14 +571,14 @@
 					"color": "var(--wp--preset--color--theme-7)"
 				}
 			},
-			"woocommerce/product-summary" : {
+			"woocommerce/product-summary": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-4)"
 				}
 			},
 			"woocommerce/product-title": {
 				"typography": {
-					"fontSize":  "var(--wp--preset--font-size--large)",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"lineHeight": "1.18"
 				}
 			}
@@ -677,7 +678,7 @@
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "400",
 					"lineHeight": "1.71",
-					"letterSpacing":"0.06rem",
+					"letterSpacing": "0.06rem",
 					"textTransform": "uppercase"
 				}
 			},
@@ -714,7 +715,7 @@
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--inter)",
-			"fontSize":  "var(--wp--preset--font-size--medium)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
 			"fontStyle": "normal",
 			"fontWeight": "300",
 			"lineHeight": "1.5625"


### PR DESCRIPTION
Follow-up to #362 ([WOOTHME-416](https://linear.app/a8c/issue/WOOTHME-416/add-additional-color-palettes-4-additional-10-total)), fixing three issues found while auditing the dark schemes. Two commits.

## 1. Section Style 2/3 headings and links were still dark-on-dark

The #362 overrides set only the sections' base text color, but Styles 2 and 3 also pin `elements.heading` and `elements.link` (`theme-5` / `theme-1`), and element rules beat the base color. Headings like "Honest materials" stayed dark on the dark bands. The dark variations now override both elements to `theme-2` as well.

## 2. Pinned outline button in the About pattern

The "Shop now" outline button in `about-left-aligned-image-description-button` hardcoded `theme-1` text, bypassing both core's outline inheritance and the section overrides: invisible on the Style 2 band in dark schemes. The pin is removed; it inherits the band text like every other outline button (same white-on-dark look in light schemes).

## 3. Standalone outline buttons lost their ink color

After #362, outline buttons inherited context everywhere, which regressed standalone ones (e.g. Best sellers "Shop now"): on plain backgrounds they rendered in the muted `theme-4` body color. New mechanism:

- `--wp--custom--outline-button-color` defaults to `theme-2` (`settings.custom` in theme.json), applied by the outline variation css to links without an explicit color.
- `style.css` resets the property to `currentColor` inside the three section styles and covers, so outline buttons there keep following the local text color.
- Explicit user-chosen colors still win (`:not(.has-text-color)` guard).

Implementation note: theme.json `css` strings are split on `&` and any part containing more than one `{}` rule is silently discarded; multiple rules must be `&`-separated (`&.foo` compound vs `& .foo` descendant). This is why the rule is written the way it is.

## Testing

1. Flip between a light scheme and each dark scheme in Site Editor > Styles (re-apply to refresh saved snapshots).
2. Section Style 2/3 sections: headings, body text, links, and outline buttons all render in the scheme's ink on the band.
3. Best sellers pattern: "Shop now" outline renders in the ink color (theme-2) in every scheme.
4. Outline buttons on covers stay white; a manually colored outline button keeps its chosen color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)