### PR TITLE
Purple: Fix mini cart drawer legibility across color schemes

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -81,6 +81,38 @@ textarea {
 }
 
 /* ==========================================================================
+   WooCommerce — Mini cart
+   ========================================================================== */
+
+/* WooCommerce hardcodes a white drawer surface; the drawer text follows the
+ * scheme, so on dark palettes it rendered light-on-white. Paint the surface
+ * with theme-1 (white in light schemes, so no change there). The overlay
+ * ancestor bumps specificity above WooCommerce's own drawer rule. */
+.wc-block-components-drawer__screen-overlay .wc-block-components-drawer,
+.wc-block-components-drawer .wp-block-woocommerce-mini-cart-contents {
+	background-color: var(--wp--preset--color--theme-1);
+}
+
+/* WooCommerce's outlined component buttons (e.g. the mini cart "View cart")
+ * use currentColor and a hardcoded #1e1e1e hover; align them with the
+ * theme's outline button style. The doubled class outranks WooCommerce's
+ * own rules regardless of stylesheet order. */
+.wc-block-components-button.wc-block-components-button:not(.is-link).outlined,
+.wc-block-components-button.wc-block-components-button:not(.is-link).is-style-outline {
+	color: var(--wp--custom--outline-button-color);
+}
+
+.wc-block-components-button.wc-block-components-button:not(.is-link).outlined:hover,
+.wc-block-components-button.wc-block-components-button:not(.is-link).outlined:focus,
+.wc-block-components-button.wc-block-components-button:not(.is-link).outlined:active,
+.wc-block-components-button.wc-block-components-button:not(.is-link).is-style-outline:hover,
+.wc-block-components-button.wc-block-components-button:not(.is-link).is-style-outline:focus,
+.wc-block-components-button.wc-block-components-button:not(.is-link).is-style-outline:active {
+	background-color: color-mix(in srgb, currentColor 5%, transparent);
+	color: var(--wp--custom--outline-button-color);
+}
+
+/* ==========================================================================
    WooCommerce — Checkout
    ========================================================================== */
 
@@ -420,6 +452,7 @@ textarea {
 	background-color: #fff;
 	border: 0;
 	box-shadow: none;
+	color: #111111;
 	flex: 1 1 auto;
 	font-weight: 400;
 	margin: 0;
@@ -439,11 +472,13 @@ textarea {
 
 .wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--minus {
 	background-color: #fff;
+	color: #111111;
 	order: 1;
 }
 
 .wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--plus {
 	background-color: #fff;
+	color: #111111;
 	order: 3;
 }
 


### PR DESCRIPTION
Follow-up to #362/#365 ([WOOTHME-416](https://linear.app/a8c/issue/WOOTHME-416/add-additional-color-palettes-4-additional-10-total)): the mini cart drawer was unreadable under the dark schemes because WooCommerce hardcodes a white drawer surface while the text follows the scheme (light ink on white).

## Changes (all `style.css`)

1. **Drawer surface**: `.wc-block-components-drawer` and the mini-cart contents block now use `theme-1`. Light schemes are unchanged (theme-1 is white); dark schemes get the scheme surface with their light ink on it. Inner mini cart blocks use `background: inherit`, including the title's fade-out mask, so everything follows.
2. **Quantity stepper text**: the stepper keeps its deliberately fixed `#fff` control surface (WC [#66140](https://github.com/woocommerce/woocommerce/issues/66140) workaround from #258), so its input digits and +/- glyphs are pinned to `#111111` instead of inheriting scheme ink. These lines live inside the workaround section and revert together with it.
3. **Outlined component buttons**: WooCommerce's `outlined`/`is-style-outline` component buttons (mini cart "View cart", also used in cart/checkout flows) now take their color from `--wp--custom--outline-button-color`, matching the theme's outline button style from #365, with the theme's 5% `color-mix` hover wash replacing the hardcoded `#1e1e1e` hover. Doubled-class selectors outrank WooCommerce's rules regardless of stylesheet order.

The `purple/hidden-mini-cart-contents` pattern itself needed no changes; all problems were in WooCommerce's hardcoded chrome.

## Testing

1. Add products to the cart and open the mini cart drawer in a light scheme: identical to before.
2. Switch to Autumn / Vibrant Ice / Electric Kiwi (re-apply to refresh snapshots): drawer surface is dark, title/products/subtotal render in light ink.
3. Quantity stepper: white control, dark digits and +/- in every scheme.
4. "View cart" renders as an ink-colored outline button with the subtle wash on hover; "Proceed to checkout" keeps the default button style.
5. Empty cart state: message and "Return to shop" legible in all schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)