### PR TITLE
Purple: Raise minimum WordPress version to 7.0

### DIFF
--- a/purple/readme.txt
+++ b/purple/readme.txt
@@ -1,6 +1,6 @@
 === Purple ===
 Contributors: Automattic
-Requires at least: 6.8
+Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 7.2
 Stable tag: 1.0.0

--- a/purple/style.css
+++ b/purple/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/purple
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Purple is the new WooCommerce starter theme, fully built with blocks and ready for modern commerce. Designed with apparel stores in mind, it features clean styles and a simplistic color palette that adapts to any brand. Packed with commerce-ready templates and curated patterns, Purple offers a versatile foundation for launching your next online store with ease and precision.
-Requires at least: 6.8
+Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 7.2
 Version: 1.0.0


### PR DESCRIPTION
Fixes #332 ([WOOTHME-394](https://linear.app/a8c/issue/WOOTHME-394/minimum-wordpress-version-doesnt-match-required-features))

## Changes

The theme declared `Requires at least: 6.8`, but ships features that need newer WordPress:

- The header uses viewport-based block visibility (`metadata.blockVisibility`), added in WordPress 7.0.
- The product filter sidebars use the core Accordion block, added in WordPress 6.9.

This bumps `Requires at least` to `7.0` in `style.css` and `readme.txt` (the only two places the minimum is declared; `Tested up to: 7.0` already matched). Per the issue discussion, raising the minimum beats maintaining CSS and block fallbacks for one older version, and matches the usual "current minus 1" policy with 7.1 releasing shortly.

## Testing

1. `grep -rn "6.8"` in the theme returns nothing.
2. Theme headers in `style.css` and `readme.txt` both read `Requires at least: 7.0`.
3. On a WordPress 7.0 site, the theme installs and activates with no version warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)