### PR TITLE
Purple: Use empty alt on decorative service and check icons

### DIFF
--- a/purple/patterns/about-alternating-columns.php
+++ b/purple/patterns/about-alternating-columns.php
@@ -23,7 +23,7 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
@@ -33,7 +33,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
@@ -43,7 +43,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
@@ -79,7 +79,7 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","margin":{"bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","orientation":"vertical"}} -->
 <div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--20)"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
@@ -89,7 +89,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
@@ -99,7 +99,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->

--- a/purple/patterns/about-features-2-columns.php
+++ b/purple/patterns/about-features-2-columns.php
@@ -27,7 +27,7 @@
 <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","orientation":"vertical"}} -->
 <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -37,7 +37,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -47,7 +47,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg","width":"24px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="<?php esc_attr_e( 'Check icon', 'purple' ); ?>" style="width:24px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-check.svg" alt="" style="width:24px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/purple/patterns/store-features-four-columns-alternative.php
+++ b/purple/patterns/store-features-four-columns-alternative.php
@@ -17,7 +17,7 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-pin.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-pin.svg" alt="<?php esc_attr_e( 'Pin icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-pin.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -31,7 +31,7 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg" alt="<?php esc_attr_e( 'Gift icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -49,7 +49,7 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="<?php esc_attr_e( 'Return icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -63,7 +63,7 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-payment.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-payment.svg" alt="<?php esc_attr_e( 'Payment icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-payment.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 

--- a/purple/patterns/store-features-four-columns.php
+++ b/purple/patterns/store-features-four-columns.php
@@ -18,7 +18,7 @@
 <div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"32px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:32px"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-support.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-2"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-support.svg" alt="<?php esc_attr_e( 'Support icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-support.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -42,7 +42,7 @@
 <div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"32px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:32px"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-2"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg" alt="<?php esc_attr_e( 'Gift icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -70,7 +70,7 @@
 <div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"32px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:32px"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-2"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="<?php esc_attr_e( 'Return icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -94,7 +94,7 @@
 <div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"32px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:32px"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-repair.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-2"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-repair.svg" alt="<?php esc_attr_e( 'Repair icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-repair.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/purple/patterns/store-features-three-columns-alternative.php
+++ b/purple/patterns/store-features-three-columns-alternative.php
@@ -15,7 +15,7 @@
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70);flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px;margin-bottom:var(--wp--preset--spacing--10)"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-craft.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-craft.svg" alt="<?php esc_attr_e( 'Craft icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-craft.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -35,7 +35,7 @@
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70);flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px;margin-bottom:var(--wp--preset--spacing--10)"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-wool.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-wool.svg" alt="<?php esc_attr_e( 'Wool icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-wool.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -55,7 +55,7 @@
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70);flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center","justifyContent":"center"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px;margin-bottom:var(--wp--preset--spacing--10)"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-color.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-color.svg" alt="<?php esc_attr_e( 'Color icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-color.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 

--- a/purple/patterns/store-features-three-columns.php
+++ b/purple/patterns/store-features-three-columns.php
@@ -15,7 +15,7 @@
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70);flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px;margin-bottom:var(--wp--preset--spacing--10)"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.svg" alt="<?php esc_attr_e( 'Truck icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -35,7 +35,7 @@
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70);flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px;margin-bottom:var(--wp--preset--spacing--10)"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg" alt="<?php esc_attr_e( 'Gift icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-gift.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -55,7 +55,7 @@
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70);flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center","justifyContent":"center"}} -->
 <div class="wp-block-group" style="padding-right:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px;margin-bottom:var(--wp--preset--spacing--10)"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-1"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="<?php esc_attr_e( 'Return icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 

--- a/purple/patterns/store-features-two-columns.php
+++ b/purple/patterns/store-features-two-columns.php
@@ -15,7 +15,7 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-2"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.svg" alt="<?php esc_attr_e( 'Truck icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-truck.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -35,7 +35,7 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"border":{"radius":"999px","width":"1px"}},"borderColor":"theme-6","layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-theme-6-border-color" style="border-radius:999px;border-width:1px"><!-- wp:image {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg","width":"32px","sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"var:preset|duotone|duotone-2"}}} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="<?php esc_attr_e( 'Return icon', 'purple' ); ?>" style="width:32px"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icon-return.svg" alt="" style="width:32px"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Fixes #343 ([WOOTHME-405](https://linear.app/a8c/issue/WOOTHME-405/decorative-service-icons-have-redundant-alt-text))

## Changes

The service and check icons used alt text ("Truck icon", "Gift icon", "Check icon", etc.) that repeats the visible text next to each image, creating redundant screen-reader output. All 25 decorative icons across seven patterns now use `alt=""` so assistive tech skips them:

- `store-features-*` (5 patterns, 16 icons)
- `about-alternating-columns` (6 check icons)
- `about-features-2-columns` (3 check icons)

The removed strings were translation calls (`esc_attr_e`), so this also drops 11 unnecessary translatable strings. Only the `img` tags change; block attributes are untouched.

## Testing

1. Insert a store-features or About features pattern and inspect an icon: `alt=""`.
2. With a screen reader (or the accessibility tree), each feature announces only its text (e.g. "Free Shipping"), not "Truck icon, Free Shipping".

🤖 Generated with [Claude Code](https://claude.com/claude-code)