### PR TITLE
Purple: Remove redundant Sort by label and fix sorting control alignment

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -23,11 +23,7 @@
 <div class="wp-block-group alignwide"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}}},"textColor":"theme-2"} -->
-<p class="has-theme-2-color has-text-color has-link-color"><?php esc_html_e('Sort by:', 'purple');?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+<div class="wp-block-group"><!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","useLabel":true,"style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>

--- a/purple/patterns/product-grid-without-filters.php
+++ b/purple/patterns/product-grid-without-filters.php
@@ -15,11 +15,7 @@
 <div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:woocommerce/product-results-count {"metadata":{"blockVisibility":{"viewport":{"mobile":false}}}} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><?php esc_html_e('Sort by:', 'purple');?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+<div class="wp-block-group"><!-- wp:woocommerce/catalog-sorting {"fontSize":"medium","useLabel":true,"style":{"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/purple/style.css
+++ b/purple/style.css
@@ -266,12 +266,29 @@ textarea {
  * Continues PR #82 exploration: https://github.com/woocommerce/woo-themes/pull/82
  * Closed/open styles from Figma Dropdown/Default (1:6531) and Dropdown/Open Links (37:1153).
  * Strip native chrome with appearance: none first; opt into base-select for the picker. */
-.woocommerce.wc-block-catalog-sorting {
-	font-size: var(--wp--preset--font-size--medium) !important;
+/* The block renders its own "Sort by" label beside the select; as inline
+ * content the label sits on the baseline while the select is middle-aligned,
+ * so their text drifts apart vertically. Center both in a flex row. */
+/* The frontend nests label + select in form.woocommerce-ordering; the
+ * editor preview renders them inside a Disabled wrapper instead
+ * (.components-disabled). Flex every possible parent so the pair centers
+ * and gaps identically in either context. */
+.woocommerce.wc-block-catalog-sorting,
+.woocommerce.wc-block-catalog-sorting .components-disabled,
+.woocommerce.wc-block-catalog-sorting form.woocommerce-ordering {
+	align-items: center;
+	display: flex;
+	gap: 0.3em;
+	margin-bottom: 0;
 }
 
-.woocommerce.wc-block-catalog-sorting form.woocommerce-ordering {
-	margin-bottom: 0;
+/* WooCommerce's label rules add bottom and right margins that push the
+ * label off-center and double the gap; the flex gap handles spacing. The
+ * doubled-class selector beats WooCommerce's editor-only
+ * label.orderby-label margin-right rule. */
+.woocommerce.wc-block-catalog-sorting label,
+.woocommerce.wc-block-catalog-sorting.wc-block-catalog-sorting label.orderby-label {
+	margin: 0;
 }
 
 .woocommerce.wc-block-catalog-sorting select.orderby {
@@ -287,7 +304,7 @@ textarea {
 	color: var(--wp--preset--color--theme-2);
 	cursor: pointer;
 	font-family: inherit;
-	font-size: var(--wp--preset--font-size--medium) !important;
+	font-size: inherit;
 	font-weight: inherit;
 	line-height: 1.5625;
 	outline: none;
@@ -369,7 +386,7 @@ textarea {
 		color: var(--wp--preset--color--theme-2);
 		display: flex;
 		flex-direction: column;
-		font-size: var(--wp--preset--font-size--medium);
+		font-size: inherit;
 		gap: 0;
 		line-height: 1.5625;
 		margin-block-start: 12px;
@@ -390,7 +407,7 @@ textarea {
 		background-color: transparent;
 		box-sizing: border-box;
 		color: var(--wp--preset--color--theme-2);
-		font-size: var(--wp--preset--font-size--medium);
+		font-size: inherit;
 		gap: 0;
 		line-height: 1.5625;
 		min-block-size: auto;


### PR DESCRIPTION
Fixes #352 ([WOOTHME-417](https://linear.app/a8c/issue/WOOTHME-417/remove-sort-by-text-before-the-catalog-sorting))

## Changes

The catalog patterns rendered a decorative "Sort by:" paragraph in front of the Catalog Sorting block, duplicating the label the block renders itself.

**Patterns** (`product-grid-with-filters`, `product-grid-without-filters`):
- Remove the redundant paragraph.
- Set `useLabel: true` on the Catalog Sorting block so its built-in accessible `<label for>` renders by default. This follows the note on the ticket: the visible label stays (via the block's toggle, where merchants can control it), only the duplicate is gone.

**`style.css`** (catalog sorting section):
- Lay out the label + select as a centered flex pair with a `0.3em` gap. Three parents are covered because the markup differs per context: `form.woocommerce-ordering` on the frontend, the `Disabled` wrapper in the editor preview, and the block wrapper itself.
- Zero WooCommerce's label margins (including the editor-only `label.orderby-label` `margin-right` rule) so the flex gap is the only spacing and the label doesn't sit off-center.
- Replace the `!important` pinned font sizes with inheritance (`font-size: inherit` on the select, options, and base-select picker; the forced wrapper rule is removed). The block's font-size control in the editor now works: the whole control follows the chosen size, and the unitless line-height scales with it. At the default medium size the Figma dropdown design renders exactly as before.

## Testing

1. Shop page: the control reads "Sort by [select]" once, aligned on the row with the results count, `0.3em` gap.
2. Site Editor: the block preview matches the frontend (same gap and alignment), and changing the block's font size resizes label, select, and the open dropdown.
3. Keyboard/screen reader: the select still has an associated label element.
4. Base-select browsers (Chrome 135+): custom picker unchanged at medium; scales with font size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)