### PR TITLE
Purple: Restore visible keyboard focus on the catalog sorting control

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -313,6 +313,15 @@ textarea {
 	vertical-align: middle;
 }
 
+/* The custom styling strips the border and browser outline, so keyboard
+ * focus was invisible (WOOTHME-404). revert restores the browser's native
+ * focus ring, matching the rings on unstyled links and buttons; mouse
+ * focus stays clean via outline: none above. */
+.woocommerce.wc-block-catalog-sorting select.orderby:focus-visible {
+	outline: revert;
+	outline-offset: 2px;
+}
+
 @supports (appearance: base-select) {
 	.woocommerce.wc-block-catalog-sorting select.orderby,
 	.woocommerce.wc-block-catalog-sorting select.orderby::picker(select) {


### PR DESCRIPTION
Fixes #342 ([WOOTHME-404](https://linear.app/a8c/issue/WOOTHME-404/catalog-sorting-control-lacks-a-visible-focus-style))

## Changes

The catalog sorting select strips its border and browser outline as part of the custom dropdown design, which left keyboard focus with no visible indicator; tabbing onto the control looked like focus had skipped it.

One rule in `style.css`: on `:focus-visible` the outline is set to `revert`, handing the property back to the browser so its native focus ring renders (Chrome's two-tone ring, Safari's blue, etc.), with `outline-offset: 2px` for spacing. Rationale for `revert` over a custom ring: every other focusable element on the page shows the browser's native ring, so this keeps focus indication consistent within each browser instead of introducing the one custom-colored ring on the page. Mouse/touch focus stays ringless via the existing `outline: none`.

## Testing

1. On the shop page, Tab to the sorting control: the browser's standard focus ring appears around the select, offset 2px.
2. Click the control with a mouse: no ring, as before.
3. Works in both the base-select custom picker (Chrome 135+) and the styled-native-select fallback, and in every color scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)