### PR TITLE
Purple: Load parent assets from the template directory

### DIFF
--- a/purple/functions.php
+++ b/purple/functions.php
@@ -320,12 +320,13 @@ if ( ! function_exists( 'purple_styles' ) ) :
 	 */
 	function purple_styles() {
 
-		// Register theme stylesheet.
+		// Register theme stylesheet. Use the template (parent) directory and
+		// version so the file still resolves when a child theme is active.
 		wp_register_style(
 			'purple-style',
-			get_stylesheet_directory_uri() . '/style.css',
+			get_template_directory_uri() . '/style.css',
 			array(),
-			wp_get_theme()->get( 'Version' )
+			wp_get_theme( get_template() )->get( 'Version' )
 		);
 
 		// Enqueue theme stylesheet.
@@ -351,9 +352,9 @@ if ( ! function_exists( 'purple_scripts' ) ) :
 	function purple_scripts() {
 		wp_enqueue_script(
 			'purple-navigation-dropdown',
-			get_stylesheet_directory_uri() . '/assets/js/navigation-dropdown.js',
+			get_template_directory_uri() . '/assets/js/navigation-dropdown.js',
 			array(),
-			wp_get_theme()->get( 'Version' ),
+			wp_get_theme( get_template() )->get( 'Version' ),
 			array(
 				'in_footer' => true,
 				'strategy'  => 'defer',


### PR DESCRIPTION
Fixes #333 ([WOOTHME-395](https://linear.app/a8c/issue/WOOTHME-395/child-theme-support-parent-assets-use-get-stylesheet-directory-uri))

## Changes

`purple_styles()` and `purple_scripts()` enqueued Purple's own `style.css` and `assets/js/navigation-dropdown.js` with `get_stylesheet_directory_uri()`, which resolves to the child theme's directory when one is active: the theme's CSS was silently replaced by the child's header-only `style.css`, and the navigation script returned 404.

Both now use `get_template_directory_uri()`, and their cache-busting version comes from `wp_get_theme( get_template() )->get( 'Version' )` so it tracks Purple's version rather than the active child's.

## Testing

Verified end to end on a local site with a bare child theme (`Template: purple`, version 0.1.0) activated:

- Both assets resolve to `wp-content/themes/purple/...` (the parent) and return HTTP 200.
- Both carry `?ver=1.0.0` (Purple's version), not the child's 0.1.0.
- With no child theme active, output is byte-identical to before (template and stylesheet directories coincide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)