### PR TITLE
Purple: Use the WooCommerce shop permalink in the CTA pattern

### DIFF
--- a/purple/patterns/cta-with-images.php
+++ b/purple/patterns/cta-with-images.php
@@ -38,7 +38,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"underline-link","style":{"typography":{"textAlign":"center"}}} -->
-<p class="has-text-align-center underline-link"><a href="/shop"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></p>
+<p class="has-text-align-center underline-link"><a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'shop' ) : home_url( '/' ) ); ?>"><?php esc_html_e( 'Shop now', 'purple' ); ?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>


### PR DESCRIPTION
Fixes #334 ([WOOTHME-396](https://linear.app/a8c/issue/WOOTHME-396/hardcoded-shop-url-shop-breaks-non-default-store-setups))

## Changes

`patterns/cta-with-images.php` hardcoded `href="/shop"`, which assumes a domain-root install, the default `shop` slug, and pretty permalinks. The "Shop now" link now uses `esc_url( wc_get_page_permalink( 'shop' ) )`, which resolves the store's actual Shop page on any setup (custom page or slug, subdirectory, multisite, translated URLs, plain permalinks). A `function_exists` guard falls back to `home_url( '/' )` when WooCommerce is inactive, since pattern files execute at registration; this is the first direct WC function call in a pattern, and `wc_get_page_permalink` itself already falls back to home when no Shop page is configured.

## Testing

1. Insert the "CTA with images" pattern: "Shop now" links to the site's actual shop page permalink (verified rendering `http://purple.local/shop/` locally).
2. Change the Shop page in WooCommerce settings or switch to plain permalinks: the link follows.
3. With WooCommerce deactivated, the pattern renders without errors and links to the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)