### PR TITLE
Purple: Square the coupon and gift card fields on cart and checkout

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -159,6 +159,16 @@ textarea {
 	box-shadow: 0 0 0 0.5px var(--wp--preset--color--theme-6);
 }
 
+/* Coupon and gift card fields sit in the order summary, where WooCommerce's
+ * component styles tie the generic override above on specificity and load
+ * later, keeping their rounded corners. The doubled component class wins
+ * the tie; the cart block and extension fields that reuse the text-input
+ * component (e.g. Gift Cards) get the same treatment. */
+.wp-block-woocommerce-cart .wc-block-components-text-input.wc-block-components-text-input input,
+.wp-block-woocommerce-checkout .wc-block-components-text-input.wc-block-components-text-input input {
+	border-radius: 0;
+}
+
 /* ==========================================================================
    WooCommerce — My Account
    ========================================================================== */


### PR DESCRIPTION
Fixes #349 ([WOOTHME-414](https://linear.app/a8c/issue/WOOTHME-414/coupon-and-gift-card-fields-should-be-square))

## Changes

The coupon and gift card fields kept WooCommerce's rounded corners while every other checkout field was square. Cause: they render in the order summary through the generic `wc-block-components-text-input` component, whose WooCommerce rules tie the theme's existing `border-radius: 0` override on specificity and load later in the cascade, so the tie went to WooCommerce.

One rule in `style.css`: a doubled component class (`.wc-block-components-text-input.wc-block-components-text-input input`) scoped to the cart and checkout blocks wins the tie and squares every text-input component inside them, including fields added by extensions that reuse the component.

## Testing

1. Add a product to the cart; on the cart and checkout pages open "Add coupon": the field has square corners matching the address inputs (verified locally).
2. Gift Cards extension: not installed locally, so not directly verified; its checkout field renders through the same text-input component inside the checkout block, which this selector covers. Worth confirming during extension testing on staging.
3. Regular address/contact fields: unchanged (already square; the new rule agrees with the existing one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)