### PR TITLE
Purple: Equalize grouped product quantity stepper widths

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -479,6 +479,21 @@ textarea {
 	min-height: 44px;
 }
 
+/* WooCommerce unsets the stepper width inside add-to-cart-with-options,
+ * so grouped-product steppers are content-sized, and a number input's
+ * intrinsic width varies with its max attribute: rows with and without
+ * managed stock rendered uneven widths (WOOTHME-413). Pin the input to
+ * the same 40px floor the workaround below uses so every stepper sizes
+ * identically, and keep the selector from being squeezed by long titles
+ * in its nowrap row; those wrap inside the label instead. */
+.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .wc-block-add-to-cart-with-options-grouped-product-item-selector {
+	flex-shrink: 0;
+}
+
+.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input {
+	width: 40px;
+}
+
 /* Editor preview uses legacy .qty classes; frontend adds __input. */
 .woocommerce .wc-block-components-quantity-selector input.qty,
 .wc-block-components-quantity-selector input.qty,


### PR DESCRIPTION
Fixes #348 ([WOOTHME-413](https://linear.app/a8c/issue/WOOTHME-413/grouped-product-picker-alignment-is-off))

## Root cause

WooCommerce's add-to-cart-with-options stylesheet sets `width: unset` on `.wc-block-components-quantity-selector` (with a doubled class that beats its own generic `width: 107px` rule), so grouped-product steppers are content-sized. A number input's intrinsic width depends on its `max` attribute, so children with managed stock rendered narrower steppers than unlimited ones; long product titles could additionally squeeze rows in the item's nowrap flex layout. That's why the demo's Cashmere Essentials Set (mixed stock management) showed uneven pickers while sample data with uniform stock settings didn't.

## Changes (`style.css`)

- Pin the grouped stepper input to `width: 40px`, the same floor the existing stepper workaround uses as `min-width`, so every stepper's content width is identical regardless of stock/max attributes.
- `flex-shrink: 0` on the item selector so long titles can't compress a row's stepper; titles wrap inside the fill label instead.

Scoped to `.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item`; other stepper contexts (cart, mini cart) are untouched.

Verified live against https://purpledemo.wpcomstaging.com/product/cashmere-essentials-set/ by injecting the rule: all steppers equalize.

Upstream note: WooCommerce unsetting its own fixed component width in this context looks like the real bug and may deserve an issue on woocommerce/woocommerce; this fix is safe either way.

## Testing

1. View a grouped product whose children mix managed and unmanaged stock (this is what the sample Logo Collection does NOT do; the demo cashmere set does): all quantity steppers render the same width.
2. Give a child product a very long name: its row wraps the title, the stepper stays full-width.
3. Simple/variable product steppers and cart/mini-cart steppers: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)