### PR TITLE
Purple: Fix grouped stepper width rule losing to the stepper workaround

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -490,7 +490,9 @@ textarea {
 	flex-shrink: 0;
 }
 
-.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input {
+/* The doubled class outranks the width: auto in the stepper workaround
+ * below, which ties this rule's specificity otherwise and loads later. */
+.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input.wc-block-components-quantity-selector__input {
 	width: 40px;
 }
 


### PR DESCRIPTION
Follow-up to #374 ([WOOTHME-413](https://linear.app/a8c/issue/WOOTHME-413/grouped-product-picker-alignment-is-off), GitHub #348): the fix worked when console-injected but not when shipped, as seen on the demo site after deploy.

## Root cause

The grouped stepper rule from #374 and the stepper workaround's input rule both compute to (0,3,1) specificity:

```
.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .wc-block-components-quantity-selector input.wc-block-components-quantity-selector__input        /* #374, width: 40px */
.woocommerce .wc-block-components-quantity-selector input.qty                                                      /* workaround, width: auto */
```

The workaround sits later in the file, so its `width: auto` won the tie and the 40px pin never applied. Console injection during #374's verification masked this: injected styles always come last in the cascade.

## Change

Double the input class on the grouped rule (`...__input.wc-block-components-quantity-selector__input`), lifting it to (0,4,1) so it outranks the workaround regardless of position, the same tie-breaker pattern used elsewhere in the file. Removing `width: auto` from the workaround instead was considered and rejected: it counters WooCommerce's classic `.woocommerce .quantity .qty { width: 3.631em }` on simple and variable product steppers.

## Testing

1. On a grouped product with mixed managed stock (one child with stock quantity, one without), all quantity inputs compute to exactly `40px` and the steppers render equal width. Verified locally against the shipped stylesheet, no injection: `[...document.querySelectorAll('.wc-block-components-quantity-selector input')].map(i => getComputedStyle(i).width)` returns `['40px', '40px', '40px']`.
2. Simple and variable product steppers: unchanged.
3. After deploy, the demo's Cashmere Essentials Set should finally equalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)