### PR TITLE
Purple: Align grouped product steppers flush with the content edge

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -487,7 +487,11 @@ textarea {
  * identically, and keep the selector from being squeezed by long titles
  * in its nowrap row; those wrap inside the label instead. */
 .wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .wc-block-add-to-cart-with-options-grouped-product-item-selector {
+	/* WooCommerce reserves min-width: 6.8em and end-aligns the stepper
+	 * inside it; with the steppers pinned uniform that just indents them
+	 * off the content edge. Let the wrapper hug the stepper instead. */
 	flex-shrink: 0;
+	min-width: 0;
 }
 
 /* The doubled class outranks the width: auto in the stepper workaround


### PR DESCRIPTION
Follow-up to #374/#376 ([WOOTHME-413](https://linear.app/a8c/issue/WOOTHME-413/grouped-product-picker-alignment-is-off))

## Changes

WooCommerce's grouped item selector CSS reserves space and end-aligns the stepper within it:

```css
:where(.wp-block-group.is-layout-flex:not(.is-vertical) > .wc-block-add-to-cart-with-options-grouped-product-item-selector) {
	min-width: 6.8em;
	text-align: right; /* left in the RTL stylesheet */
}
```

With the steppers now pinned to a uniform width, that reservation only indents each stepper ~7px inside its wrapper, leaving the whole column out of line with the content edge (visible against the Add to cart button). Adding `min-width: 0` to the theme's existing wrapper rule lets the wrapper hug the stepper, making the end-alignment moot in both LTR and RTL. The `:where()` on WooCommerce's rule has zero specificity, so no tie-breaking needed.

## Testing

1. Grouped product page: stepper left edges align flush with the content column (same edge as the Add to cart button), all equal width.
2. RTL locale: steppers flush with the right content edge.
3. Simple/variable steppers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)