### PR TITLE
Purple: Remove custom heading margins from post content

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -45,17 +45,6 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 	--wp--custom--outline-button-color: currentColor;
 }
 
-/*
- * Tighten margin when a heading follows another heading in post content.
- * The extra top-margin in theme.json signals a section break above; when
- * two headings are adjacent the subordinate one should sit closer to its
- * parent rather than read as a new section. The class is unwrapped from
- * :where() so we beat the theme.json-generated `:root :where(...)` rule
- * (which is 0,1,0 specificity from :root).
- */
-.wp-block-post-content :is(h1, h2, h3, h4, h5, h6) + :is(h1, h2, h3, h4, h5, h6) {
-	margin-top: var(--wp--style--block-gap);
-}
 
 /* ==========================================================================
    Forms

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -348,17 +348,6 @@
 			"core/post-comments-form": {
 				"css": "& .comment-form { margin-top: var(--wp--preset--spacing--20); }"
 			},
-			"core/post-content": {
-				"elements": {
-					"heading": {
-						"spacing": {
-							"margin": {
-								"top": "var(--wp--preset--spacing--50)"
-							}
-						}
-					}
-				}
-			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",


### PR DESCRIPTION
Fixes #329 ([WOOTHME-411](https://linear.app/a8c/issue/WOOTHME-411/remove-custom-heading-margins-from-post-content))

## Changes

Two removals that only existed as a pair:

- `theme.json`: the `styles.blocks.core/post-content` entry giving headings an extra `spacing-50` top margin (the entry contained nothing else).
- `style.css`: the high-specificity companion rule that tightened that margin back to the block gap when headings were adjacent.

Headings inside post and page content now take the theme's standard block gap, so spacing renders identically in the page editor, post editor, pattern editor, and front end, and no global rule overrides spacing a user sets on a heading. Per the issue, any layout that wants a larger break above a heading should declare it explicitly in its pattern; none currently do, and the key layouts read fine with the default gap (reviewed on the local site).

## Testing

1. View a blog post with several headings: heading spacing matches what the post editor shows (standard block gap, no extra jump above headings).
2. Same for a static page with long-form content.
3. Set a custom top margin on a heading inside content: it applies without being overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)