### PR TITLE
Purple: Add add-to-cart buttons to the product catalog grids

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -128,14 +128,16 @@
 <!-- wp:column {"width":"88%"} -->
 <div class="wp-block-column" style="flex-basis:88%"><!-- wp:woocommerce/product-collection {"queryId":27,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"1"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1.5625"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}}}} /--></div>
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"0","left":"0"}}}} /-->
+
+<!-- wp:woocommerce/product-button {"textAlign":"left","isDescendentOfQueryLoop":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--></div>
 <!-- /wp:group -->
 <!-- /wp:woocommerce/product-template -->
 

--- a/purple/patterns/product-grid-without-filters.php
+++ b/purple/patterns/product-grid-without-filters.php
@@ -24,14 +24,16 @@
 
 <!-- wp:woocommerce/product-collection {"queryId":26,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."},"align":"wide"} -->
 <div class="wp-block-woocommerce-product-collection alignwide"><!-- wp:woocommerce/product-template -->
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfQueryLoop":true,"style":{"dimensions":{"aspectRatio":"1"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20","left":"0"}},"typography":{"lineHeight":"1.55"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55"}}} /--></div>
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"0","left":"0"}},"typography":{"lineHeight":"1.55"}}} /-->
+
+<!-- wp:woocommerce/product-button {"textAlign":"left","isDescendentOfQueryLoop":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--></div>
 <!-- /wp:group -->
 <!-- /wp:woocommerce/product-template -->
 


### PR DESCRIPTION
Fixes #350 ([WOOTHME-415](https://linear.app/a8c/issue/WOOTHME-415/product-catalog-add-to-cart-buttons))

## Changes

Both catalog grid patterns (`product-grid-with-filters`, used by the Product Catalog, search results, and attribute taxonomy templates; `product-grid-without-filters` as its alternate) add a left-aligned Product Button under each card's price: AJAX add-to-cart for simple products, "Select options" navigation for variable and grouped.

Two supporting tweaks per card:

- The price gains an explicit `margin-bottom: 0`, so the space above the button is exactly the button's own `spacing-20` margin.
- The card group sets `blockGap: 0` as a workaround for [woocommerce/woocommerce#67314](https://github.com/woocommerce/woocommerce/issues/67314): WooCommerce renders the Product Button's spacing on the inner `<button>` instead of the block wrapper, so the wrapper would otherwise also collect the parent's layout gap and double the spacing. The other card blocks all carry explicit margins, so the zeroed gap changes nothing else. Revisit if upstream fixes the spacing placement.

## Scope

Per the issue, only the catalog. The storefront collection patterns (best sellers, featured, new arrivals), the related/upsell strips, and the New Arrivals page pattern are deliberately unchanged.

## Testing

1. Shop page: every card shows an Add to cart button under the price with a single `spacing-20` gap; simple products add via AJAX, variable products navigate to the product.
2. Search results and attribute archive pages: same (they use the same pattern).
3. Card spacing above the button is identical in every color scheme, including dark ones (button text follows the scheme fixes from #362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)