### PR TITLE
Purple: Rewrite the theme description

### DIFF
--- a/purple/readme.txt
+++ b/purple/readme.txt
@@ -9,7 +9,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Purple is the new WooCommerce starter theme, fully built with blocks and ready for modern commerce. Designed with apparel stores in mind, it features clean styles and a simplistic color palette that adapts to any brand. Packed with commerce-ready templates and curated patterns, Purple offers a versatile foundation for launching your next online store with ease and precision.
+Purple is a WooCommerce starter theme made for the Site Editor and modern commerce. Its clean styles and adaptable color system suit any catalog: fashion and clothing, jewelry, beauty, home decor, food and drink, or digital downloads. Commerce-ready templates and curated patterns cover the storefront from product pages and filterable shop views to cart and checkout. Ten color palettes and ten font pairings make it easy to match your brand in a click, and the theme works well with Jetpack blocks, supports RTL languages, and is fully translation-ready. Whether you’re launching your first online store or refreshing an established one, Purple is a versatile foundation for selling with WordPress and WooCommerce.
 
 == Changelog ==
 

--- a/purple/style.css
+++ b/purple/style.css
@@ -3,7 +3,7 @@ Theme Name: Purple
 Theme URI: https://wordpress.com/themes/purple
 Author: Automattic
 Author URI: https://automattic.com/
-Description: Purple is the new WooCommerce starter theme, fully built with blocks and ready for modern commerce. Designed with apparel stores in mind, it features clean styles and a simplistic color palette that adapts to any brand. Packed with commerce-ready templates and curated patterns, Purple offers a versatile foundation for launching your next online store with ease and precision.
+Description: Purple is a WooCommerce starter theme made for the Site Editor and modern commerce. Its clean styles and adaptable color system suit any catalog: fashion and clothing, jewelry, beauty, home decor, food and drink, or digital downloads. Commerce-ready templates and curated patterns cover the storefront from product pages and filterable shop views to cart and checkout. Ten color palettes and ten font pairings make it easy to match your brand in a click, and the theme works well with Jetpack blocks, supports RTL languages, and is fully translation-ready. Whether you’re launching your first online store or refreshing an established one, Purple is a versatile foundation for selling with WordPress and WooCommerce.
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 7.2


### PR DESCRIPTION
## Changes

Rewrites the theme description in `style.css` and `readme.txt` (kept identical in both). The new copy:

- Drops the apparel-only positioning in favor of any catalog (fashion, jewelry, beauty, home decor, food and drink, digital downloads).
- Names the storefront coverage: product pages, filterable shop views, cart, checkout.
- Calls out ten color palettes and ten font pairings, Jetpack blocks compatibility, RTL support, and translation readiness.

The palette count says ten, matching the four variations added for WOOTHME-416 (default plus nine variations).

## Testing

1. Appearance > Themes and wordpress.org/wordpress.com theme pages render the new description.
2. `style.css` header and `readme.txt` description are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)