### PR TITLE
Purple: Tighten stock indicator line height in grouped product rows

### DIFF
--- a/purple/parts/grouped-product-add-to-cart-with-options.html
+++ b/purple/parts/grouped-product-add-to-cart-with-options.html
@@ -12,7 +12,7 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
 			<div class="wp-block-group">
 				<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontWeight":400,"fontStyle":"normal"}}} /-->
-				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small"} /-->
+				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small","style":{"typography":{"lineHeight":"1.2"}}} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>


### PR DESCRIPTION
One-line design tweak: the stock indicator in the grouped product add-to-cart rows gets `lineHeight: 1.2`, so the right-aligned price + stock column sits tighter to the design's rhythm.

## Testing

1. View a grouped product (e.g. the sample Logo Collection): the "N in stock" line under each price sits closer to it.
2. Other stock indicator usages (single product) are unchanged; the tweak is scoped to this template part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)