### PR TITLE
Square classic WooCommerce form fields via the form tokens

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -56,6 +56,18 @@ textarea {
 	border-color: var(--wp--preset--color--theme-6);
 }
 
+/* WooCommerce's classic form fields (.form-row .input-text, selects,
+ * select2) and extensions rendering the same markup (e.g. Gift Cards)
+ * read these tokens; WooCommerce defines them 4px/gray on :root. The
+ * cart/checkout block components hardcode their values instead and are
+ * squared selector by selector in the sections below. On body rather
+ * than :root so this wins the tie against WooCommerce's own :root
+ * definition regardless of stylesheet order. */
+body {
+	--wc-form-border-color: var(--wp--preset--color--theme-6);
+	--wc-form-border-radius: 0;
+}
+
 /* ==========================================================================
    Table block
    ========================================================================== */
@@ -170,16 +182,19 @@ a.wc-block-components-product-name:hover {
 	border-radius: 0;
 }
 
+/* The Gift Cards extension's cart/checkout panel ships its own text input
+ * component with a hardcoded 4px radius; its classic product-page fields
+ * read --wc-form-border-radius and need no override. */
+.wc-gift-cards-text-input input {
+	border-color: var(--wp--preset--color--theme-6);
+	border-radius: 0;
+}
+
 /* ==========================================================================
    WooCommerce — My Account
    ========================================================================== */
 
 /* My Account — classic shortcode UI; https://github.com/woocommerce/woocommerce/issues/59391 */
-.woocommerce-account {
-	--wc-form-border-color: var(--wp--preset--color--theme-6);
-	--wc-form-border-radius: 0;
-}
-
 .woocommerce-account .entry-content > .woocommerce {
 	padding-top: var(--wp--preset--spacing--70);
 	padding-bottom: var(--wp--preset--spacing--90);


### PR DESCRIPTION
## What

Fixes the Gift Cards rounded form fields (Linear WOOTHME-452) at the token level instead of per-field CSS.

- Sets `--wc-form-border-radius: 0` and `--wc-form-border-color: var(--wp--preset--color--theme-6)` on `body`, site-wide. WooCommerce defines these tokens as 4px/gray on `:root`, and its classic form fields (`.form-row .input-text`, selects, select2) read them, so any classic-rendered field, including ones from extensions, inherits square corners and the theme border color with no selector overrides. `body` rather than `:root` so the theme wins the specificity tie regardless of stylesheet order (the same pattern WooCommerce's own bundled theme integrations use).
- The Gift Cards product-page fields (To/From/Message/Delivery) are classic `.form-row` markup with no radius of their own; their rounding was literally this token's 4px default, so they need nothing further.
- The one hardcoded radius in that extension, the text input in its blocks cart/checkout panel (`.wc-gift-cards-text-input input`), gets a matching override.
- Removes the now-redundant `.woocommerce-account`-scoped copy of these tokens; My Account inherits from `body` unchanged.

Note: the Cart/Checkout block components hardcode their radii and ignore these tokens; those are addressed separately in the follow-up PR.

## Testing

1. My Account pages should look exactly as before (fields square, theme-6 borders, including error states).
2. With the Gift Cards extension active, the product-page To/From/Message/Delivery fields and the "Have a gift card?" panel input on cart/checkout render square with theme-6 borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)