### PR TITLE
Square the cart and checkout block components

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -126,7 +126,7 @@ a.wc-block-components-product-name:hover {
 }
 
 /* ==========================================================================
-   WooCommerce — Checkout
+   WooCommerce — Cart & Checkout
    ========================================================================== */
 
 /* Styles for WooCommerce blocks that can't be styled via the editor yet. */
@@ -156,6 +156,13 @@ a.wc-block-components-product-name:hover {
 	border-radius: 0;
 }
 
+/* Cart scope covers the shipping calculator fields, which reuse the same
+ * components as the checkout form. */
+.wp-block-woocommerce-cart .wc-block-components-text-input:not(.has-error) input,
+.wp-block-woocommerce-cart .wc-block-components-textarea:not(.has-error),
+.wp-block-woocommerce-cart .wc-blocks-components-select:not(.has-error) .wc-blocks-components-select__select,
+.wp-block-woocommerce-cart .wc-blocks-components-select:not(.has-error) .wc-blocks-components-select__container,
+.wp-block-woocommerce-cart .wc-block-components-checkbox__input[type="checkbox"],
 .wp-block-woocommerce-checkout .wc-block-components-text-input:not(.has-error) input,
 .wp-block-woocommerce-checkout .wc-block-components-textarea:not(.has-error),
 .wp-block-woocommerce-checkout .wc-blocks-components-select:not(.has-error) .wc-blocks-components-select__select,
@@ -165,6 +172,9 @@ a.wc-block-components-product-name:hover {
 	border-radius: 0;
 }
 
+.wp-block-woocommerce-cart .wc-block-components-text-input:not(.has-error) input:focus,
+.wp-block-woocommerce-cart .wc-block-components-textarea:not(.has-error):focus,
+.wp-block-woocommerce-cart .wc-blocks-components-select:not(.has-error) .wc-blocks-components-select__select:focus,
 .wp-block-woocommerce-checkout .wc-block-components-text-input:not(.has-error) input:focus,
 .wp-block-woocommerce-checkout .wc-block-components-textarea:not(.has-error):focus,
 .wp-block-woocommerce-checkout .wc-blocks-components-select:not(.has-error) .wc-blocks-components-select__select:focus {
@@ -187,6 +197,21 @@ a.wc-block-components-product-name:hover {
  * read --wc-form-border-radius and need no override. */
 .wc-gift-cards-text-input input {
 	border-color: var(--wp--preset--color--theme-6);
+	border-radius: 0;
+}
+
+/* Square the remaining cart/checkout components WooCommerce rounds with
+ * hardcoded 4px values (no variable, no editor UI). Doubled classes beat
+ * WooCommerce's specificity ties regardless of stylesheet order. Radio
+ * inputs keep their 50% radius; circular radios are intentional. */
+.wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked::after,
+.wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control-accordion-option--checked-option-highlighted.wc-block-components-radio-control-accordion-option--checked-option-highlighted,
+.wc-block-components-radio-control--highlight-checked label.wc-block-components-radio-control__option--checked-option-highlighted.wc-block-components-radio-control__option--checked-option-highlighted,
+.wc-block-components-address-card.wc-block-components-address-card,
+.wc-block-components-local-pickup-select--multiple.wc-block-components-local-pickup-select--multiple,
+.wc-block-components-address-autocomplete-suggestions.wc-block-components-address-autocomplete-suggestions,
+.wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--minus.wc-block-components-quantity-selector__button--minus,
+.wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--plus.wc-block-components-quantity-selector__button--plus {
 	border-radius: 0;
 }
 

--- a/purple/style.css
+++ b/purple/style.css
@@ -56,6 +56,18 @@ textarea {
 	border-color: var(--wp--preset--color--theme-6);
 }
 
+/* WooCommerce's classic form fields (.form-row .input-text, selects,
+ * select2) and extensions rendering the same markup (e.g. Gift Cards)
+ * read these tokens; WooCommerce defines them 4px/gray on :root. The
+ * cart/checkout block components hardcode their values instead and are
+ * squared selector by selector in the sections below. On body rather
+ * than :root so this wins the tie against WooCommerce's own :root
+ * definition regardless of stylesheet order. */
+body {
+	--wc-form-border-color: var(--wp--preset--color--theme-6);
+	--wc-form-border-radius: 0;
+}
+
 /* ==========================================================================
    Table block
    ========================================================================== */
@@ -170,16 +182,19 @@ a.wc-block-components-product-name:hover {
 	border-radius: 0;
 }
 
+/* The Gift Cards extension's cart/checkout panel ships its own text input
+ * component with a hardcoded 4px radius; its classic product-page fields
+ * read --wc-form-border-radius and need no override. */
+.wc-gift-cards-text-input input {
+	border-color: var(--wp--preset--color--theme-6);
+	border-radius: 0;
+}
+
 /* ==========================================================================
    WooCommerce — My Account
    ========================================================================== */
 
 /* My Account — classic shortcode UI; https://github.com/woocommerce/woocommerce/issues/59391 */
-.woocommerce-account {
-	--wc-form-border-color: var(--wp--preset--color--theme-6);
-	--wc-form-border-radius: 0;
-}
-
 .woocommerce-account .entry-content > .woocommerce {
 	padding-top: var(--wp--preset--spacing--70);
 	padding-bottom: var(--wp--preset--spacing--90);


### PR DESCRIPTION
## What

Removes the last rounded corners from the cart and checkout (Linear WOOTHME-463). Stacked on #393; merge that first and this diff reduces to one commit.

The Cart/Checkout block components hardcode `border-radius: 4px` selector by selector and ignore WooCommerce's `--wc-form-border-radius` token, so unlike the classic fields in #393 these need explicit overrides:

- The existing checkout field and focus rules now also cover `.wp-block-woocommerce-cart`, which the shipping calculator fields (same components) were slipping through; section renamed Cart & Checkout to match.
- New rule squares the components the theme missed until now: the shipping/payment selected-option highlight (`.wc-block-components-radio-control--highlight-checked`), address cards, the local pickup select, the address autocomplete dropdown, and the quantity stepper's plus/minus button corners inside the already-squared container.
- Radio inputs keep their 50% radius; circular radios are intentional.
- Doubled-class selectors beat WooCommerce's specificity ties regardless of stylesheet load order.

## Testing

1. Checkout: text fields, selects, textarea, checkboxes, the coupon field, and the highlighted shipping/payment option all render square; with a saved address, the address card is square; local pickup with multiple locations shows a square select.
2. Cart: shipping calculator fields and the quantity stepper (including the +/- button corners) are square.
3. Focus states keep the theme-6 border and thin box-shadow ring on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)