### PR TITLE
Square the express payment box and WooPay phone input

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -200,10 +200,23 @@ a.wc-block-components-product-name:hover {
 	border-radius: 0;
 }
 
+/* WooCommerce Payments hardcodes a 5px radius and gray border on the
+ * WooPay save-details phone input; match the other checkout fields. */
+.woopay-save-new-user-container .save-details-form.form-row .phone-input.phone-input {
+	border-color: var(--wp--preset--color--theme-6);
+	border-radius: 0;
+}
+
 /* Square the remaining cart/checkout components WooCommerce rounds with
  * hardcoded 4px values (no variable, no editor UI). Doubled classes beat
  * WooCommerce's specificity ties regardless of stylesheet order. Radio
- * inputs keep their 50% radius; circular radios are intentional. */
+ * inputs keep their 50% radius; circular radios are intentional. The
+ * express payment box outline is drawn in three pieces: two title-row
+ * pseudo-elements hold its top corners and the content box its bottom
+ * ones; the branded express buttons keep their own rounding. */
+.wc-block-components-express-payment--checkout .wc-block-components-express-payment__title-container.wc-block-components-express-payment__title-container::before,
+.wc-block-components-express-payment--checkout .wc-block-components-express-payment__title-container.wc-block-components-express-payment__title-container::after,
+.wc-block-components-express-payment--checkout .wc-block-components-express-payment__content.wc-block-components-express-payment__content,
 .wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked::after,
 .wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control-accordion-option--checked-option-highlighted.wc-block-components-radio-control-accordion-option--checked-option-highlighted,
 .wc-block-components-radio-control--highlight-checked label.wc-block-components-radio-control__option--checked-option-highlighted.wc-block-components-radio-control__option--checked-option-highlighted,


### PR DESCRIPTION
## What

Follow-up to #394 (Linear WOOTHME-463): two rounded elements survived on the demo checkout, both from payment surfaces that only render with a payment gateway active.

- WooCommerce core draws the express payment section's outline in three pieces: `.wc-block-components-express-payment__title-container::before/::after` hold the top 4px corners either side of the "Express Checkout" title, and `...__content` holds the bottom `0 0 4px 4px`. All three are squared; fixing only the content box would leave the top corners rounded. The branded express buttons (Apple Pay, Google Pay) keep their 4px wrappers since the button artwork carries its own rounding.
- WooCommerce Payments hardcodes `border-radius: 5px` and a gray border on the WooPay save-details phone input (`client/settings/phone-input/style.scss`). It's squared with a theme-6 border to match the neighboring checkout fields.

Doubled-class selectors beat both plugins' specificity regardless of stylesheet order.

## Testing

Needs a site with WooCommerce Payments active (e.g. the demo after deploy):

1. Checkout: the "Express Checkout" box outline is fully square, including the corners either side of the title; Apple/Google Pay buttons look unchanged.
2. With WooPay's "Save my info" checked, the phone number input is square with the theme border color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)