### PR TITLE
Use logical CSS properties for better RTL support

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -333,6 +333,10 @@ a.wc-block-components-product-name:hover {
 	padding-block: 0;
 	padding-inline: 0 calc(1.5em + 10px);
 	vertical-align: middle;
+
+	&:dir(rtl) {
+		background-position: left center;
+	}
 }
 
 /* The custom styling strips the border and browser outline, so keyboard
@@ -614,7 +618,7 @@ a.wc-block-components-product-name:hover {
    ========================================================================== */
 
 .wp-block-woocommerce-cart-order-summary-heading-block textarea {
-	padding-left: 0;
+	padding-inline-start: 0;
 }
 
 .wc-block-cart-item__quantity {
@@ -690,8 +694,7 @@ a.wc-block-components-product-name:hover {
 			&::after {
 				content: "";
 				position: absolute;
-				left: 0;
-				right: 0;
+				inset-inline: 0;
 				top: 100%;
 				height: var(--purple-nav-dropdown-offset, 31.5px);
 				background: transparent;
@@ -701,14 +704,13 @@ a.wc-block-components-product-name:hover {
 
 			& > .wp-block-navigation__submenu-container {
 				top: calc(100% + var(--purple-nav-dropdown-offset, 31.5px));
-				left: -1.25rem;
+				inset-inline-start: -1.25rem;
 				z-index: 3;
 
 				&::after {
 					content: "";
 					position: absolute;
-					left: 0;
-					right: 0;
+					inset-inline: 0;
 					bottom: 100%;
 					height: var(--purple-nav-dropdown-offset, 31.5px);
 					background: transparent;
@@ -724,7 +726,7 @@ a.wc-block-components-product-name:hover {
 			}
 
 			& .wp-block-navigation__submenu-icon {
-				margin-right: 1.25rem;
+				margin-inline-end: 1.25rem;
 			}
 
 			& .wp-block-navigation-item:hover,
@@ -743,18 +745,16 @@ a.wc-block-components-product-name:hover {
 @media (max-width: 599px) {
 	:root .wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
 		/* Full-bleed overlay; horizontal indent lives on the links. */
-		padding-left: 0;
-		padding-right: 0;
+		padding-inline: 0;
 
 		/* Close button only — not the menu rows. */
 		& .wp-block-navigation__responsive-container-close {
 			top: 1.25rem;
-			right: 1.25rem;
+			inset-inline-end: 1.25rem;
 		}
 
 		& .wp-block-navigation__responsive-container-content {
-			padding-left: 0;
-			padding-right: 0;
+			padding-inline: 0;
 			align-items: stretch;
 
 			& .wp-block-navigation__container,
@@ -789,21 +789,26 @@ a.wc-block-components-product-name:hover {
 
 			/* Top-level horizontal inset. */
 			& > .wp-block-navigation__container > .wp-block-navigation-item > .wp-block-navigation-item__content {
-				padding-left: 1.25rem;
-				padding-right: 1.25rem;
+				padding-inline: 1.25rem;
 			}
 
 			/* Submenu link indent by nesting depth (30px / 60px / 80px). */
 			& .has-child .wp-block-navigation__submenu-container > .wp-block-navigation-item > .wp-block-navigation-item__content {
-				padding: 0.625rem 1.25rem 0.625rem 1.875rem;
+				padding-block: 0.625rem;
+				padding-inline-start: 1.875rem;
+				padding-inline-end: 1.25rem;
 			}
 
 			& .wp-block-navigation__submenu-container .wp-block-navigation__submenu-container > .wp-block-navigation-item > .wp-block-navigation-item__content {
-				padding: 0.625rem 1.25rem 0.625rem 3.75rem;
+				padding-block: 0.625rem;
+				padding-inline-start: 3.75rem;
+				padding-inline-end: 1.25rem;
 			}
 
 			& .wp-block-navigation__submenu-container .wp-block-navigation__submenu-container .wp-block-navigation__submenu-container > .wp-block-navigation-item > .wp-block-navigation-item__content {
-				padding: 0.625rem 1.25rem 0.625rem 5rem;
+				padding-block: 0.625rem;
+				padding-inline-start: 5rem;
+				padding-inline-end: 1.25rem;
 			}
 
 			/* Parent rows: label + chevron grid; submenu collapses below. */
@@ -839,7 +844,7 @@ a.wc-block-components-product-name:hover {
 					width: 24px;
 					height: 24px;
 					margin: 0;
-					padding-right: 1.25rem;
+					padding-inline-end: 1.25rem;
 					box-sizing: content-box;
 
 					& svg {
@@ -849,6 +854,10 @@ a.wc-block-components-product-name:hover {
 						stroke: currentColor;
 						transform: rotate(-90deg);
 						transition: transform 0.1s ease;
+					}
+
+					&:dir(rtl) svg {
+						transform: rotate(90deg);
 					}
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOTHME-399.

This PR replaces CSS properties that were hardcoded to specific directions to use logical properties that work well in LTR and RTL languages.

### How to test the changes in this Pull Request:

1. Smoke test the theme in a LTR locale and in a RTL locale.
2. In a RTL locale, go to a product archive screen and verify the Catalog Sorting chevron is aligned correctly.

Before | After
--- | ---
<img width="617" height="202" alt="imatge" src="https://github.com/user-attachments/assets/2cf9e114-205e-42e2-9658-bf4de7c84af7" /> | <img width="617" height="202" alt="imatge" src="https://github.com/user-attachments/assets/52e12321-58bc-45fb-8a30-480dab95c63b" />