### PR TITLE
Soften the selected option ring on checkout to the field border color

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -217,6 +217,8 @@ a.wc-block-components-product-name:hover {
 .wc-block-components-express-payment--checkout .wc-block-components-express-payment__title-container.wc-block-components-express-payment__title-container::before,
 .wc-block-components-express-payment--checkout .wc-block-components-express-payment__title-container.wc-block-components-express-payment__title-container::after,
 .wc-block-components-express-payment--checkout .wc-block-components-express-payment__content.wc-block-components-express-payment__content,
+.wc-block-checkout__payment-method .wc-block-components-radio-control-accordion-option.wc-block-components-radio-control-accordion-option:first-child::after,
+.wc-block-checkout__payment-method .wc-block-components-radio-control-accordion-option.wc-block-components-radio-control-accordion-option:last-child::after,
 .wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked::after,
 .wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control-accordion-option--checked-option-highlighted.wc-block-components-radio-control-accordion-option--checked-option-highlighted,
 .wc-block-components-radio-control--highlight-checked label.wc-block-components-radio-control__option--checked-option-highlighted.wc-block-components-radio-control__option--checked-option-highlighted,
@@ -226,6 +228,16 @@ a.wc-block-components-product-name:hover {
 .wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--minus.wc-block-components-quantity-selector__button--minus,
 .wc-block-components-quantity-selector > .wc-block-components-quantity-selector__button--plus.wc-block-components-quantity-selector__button--plus {
 	border-radius: 0;
+}
+
+/* WooCommerce draws the selected shipping/payment option ring with an
+ * inset box-shadow in currentColor, which reads as a heavy ink border
+ * next to the theme-6 field borders. Recolor it rather than replacing
+ * it with a border: the shadow layers over the group's own 1px outline
+ * and keeps the layout from shifting when the selection moves. */
+.wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control-accordion-option--checked-option-highlighted.wc-block-components-radio-control-accordion-option--checked-option-highlighted,
+.wc-block-components-radio-control--highlight-checked label.wc-block-components-radio-control__option--checked-option-highlighted.wc-block-components-radio-control__option--checked-option-highlighted {
+	box-shadow: inset 0 0 0 1.5px var(--wp--preset--color--theme-6);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## What

Follow-up on Linear WOOTHME-463. The selected shipping/payment option boxes rendered with a dark ring that looked out of place next to the theme-6 field borders.

- The ring is WooCommerce's `box-shadow: inset 0 0 0 1.5px currentColor` on the checked option (both the plain radio control and the payment accordion variants). It's recolored to theme-6 rather than replaced with a border: WooCommerce uses an inset shadow precisely so the layout can't shift when the selection moves between options, and the shadow layers over the group's own always-present 1px outline, so a real border would double up. The selected state stays readable through the filled radio dot and the slightly heavier 1.5px ring weight.
- Also squares the payment accordion's first/last option `::after` corner radii, two more hardcoded 4px values on the same page that the earlier passes missed.

## Testing

1. Checkout on a theme scheme: the Shipping options and Payment options boxes show light theme-6 outlines matching the neighboring fields, with no dark ring.
2. With multiple shipping options, switching the selection moves the ring without any layout shift.
3. Payment accordion (needs an active gateway, e.g. the demo): corners fully square, selected method ring matches the fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)