### PR TITLE
Thin the selected option ring to 1px

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -237,7 +237,7 @@ a.wc-block-components-product-name:hover {
  * and keeps the layout from shifting when the selection moves. */
 .wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control-accordion-option--checked-option-highlighted.wc-block-components-radio-control-accordion-option--checked-option-highlighted,
 .wc-block-components-radio-control--highlight-checked label.wc-block-components-radio-control__option--checked-option-highlighted.wc-block-components-radio-control__option--checked-option-highlighted {
-	box-shadow: inset 0 0 0 1.5px var(--wp--preset--color--theme-6);
+	box-shadow: inset 0 0 0 1px var(--wp--preset--color--theme-6);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## What

Follow-up to #397 (Linear WOOTHME-463): the selected shipping/payment option ring kept WooCommerce's 1.5px shadow thickness, which still read heavier than the 1px theme-6 field borders next to it. The inset shadow is now 1px so the ring matches the fields exactly; selection reads through the filled radio dot.

## Testing

Checkout: the Shipping options and Payment options boxes match the weight of the neighboring field borders, and switching the selection still moves the ring without layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)