### PR TITLE
Align checkout box borders with the theme-6 field borders

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -240,6 +240,26 @@ a.wc-block-components-product-name:hover {
 	box-shadow: inset 0 0 0 1px var(--wp--preset--color--theme-6);
 }
 
+/* The boxes around these components are WooCommerce ::after overlays and
+ * component borders drawn at 20% ink (or a hardcoded gray), a shade
+ * darker than the theme-6 field borders beside them; align them all. */
+.wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked::after,
+.wc-block-components-express-payment--checkout .wc-block-components-express-payment__title-container.wc-block-components-express-payment__title-container::before,
+.wc-block-components-express-payment--checkout .wc-block-components-express-payment__title-container.wc-block-components-express-payment__title-container::after,
+.wc-block-components-express-payment--checkout .wc-block-components-express-payment__content.wc-block-components-express-payment__content,
+.wc-block-components-address-card.wc-block-components-address-card,
+.wc-block-components-local-pickup-select--multiple.wc-block-components-local-pickup-select--multiple,
+.wc-block-components-address-autocomplete-suggestions.wc-block-components-address-autocomplete-suggestions {
+	border-color: var(--wp--preset--color--theme-6);
+}
+
+/* The separator lines between unselected options are 1px ::after
+ * overlays painted with a 20% ink background, not a border. */
+.wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control__option.wc-block-components-radio-control__option::after,
+.wc-block-components-radio-control--highlight-checked div.wc-block-components-radio-control-accordion-option.wc-block-components-radio-control-accordion-option::after {
+	background: var(--wp--preset--color--theme-6);
+}
+
 /* ==========================================================================
    WooCommerce — My Account
    ========================================================================== */


### PR DESCRIPTION
## What

Follow-up to #398 (Linear WOOTHME-463). The selected option ring now matches the fields, but the box edges around it still read darker: they come from WooCommerce's `::after` overlay border on the option group, painted at `color-mix(in srgb, currentColor 20%, transparent)`, which is a 20% ink gray rather than theme-6. This was most visible on the vertical edges, where the overlay border isn't doubled by the ring.

- Recolors that overlay border to theme-6 for the shipping and payment option boxes.
- Recolors the 1px separator lines between unselected options, which are `::after` overlays painted via `background`, not `border`.
- Aligns the sibling surfaces WooCommerce borders the same 20%-ink way so the page reads uniformly: the express payment box (content plus the two title-row corner pieces), address cards, the local pickup select, and the address autocomplete dropdown (hardcoded `#ddd`).
- The radio button circles keep their stronger 48%-ink border; they're controls, not container chrome.

## Testing

1. Checkout: the Shipping options and Payment options boxes read theme-6 on all four edges, identical to the neighboring field borders.
2. With multiple shipping rates, the separator lines between options match too.
3. On the demo (gateway active): express payment box outline, and with a logged-in saved address, the address card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)