### PR TITLE
Remove the selected option ring shadow

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -240,6 +240,20 @@ a.wc-block-components-product-name:hover {
 	box-shadow: none;
 }
 
+/* WooCommerce strips the group border's top or bottom edge when the
+ * first or last option is the selected one, expecting the ring to draw
+ * that edge; with the ring gone, restore the sides and their margin
+ * nudges so the box stays fully outlined. */
+.wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked--first-selected::after {
+	border-top: 1px solid var(--wp--preset--color--theme-6);
+	margin-top: 0;
+}
+
+.wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked.wc-block-components-radio-control--highlight-checked--last-selected::after {
+	border-bottom: 1px solid var(--wp--preset--color--theme-6);
+	margin-bottom: 0;
+}
+
 /* The boxes around these components are WooCommerce ::after overlays and
  * component borders drawn at 20% ink (or a hardcoded gray), a shade
  * darker than the theme-6 field borders beside them; align them all. */

--- a/purple/style.css
+++ b/purple/style.css
@@ -230,14 +230,14 @@ a.wc-block-components-product-name:hover {
 	border-radius: 0;
 }
 
-/* WooCommerce draws the selected shipping/payment option ring with an
- * inset box-shadow in currentColor, which reads as a heavy ink border
- * next to the theme-6 field borders. Recolor it rather than replacing
- * it with a border: the shadow layers over the group's own 1px outline
- * and keeps the layout from shifting when the selection moves. */
+/* WooCommerce rings the selected shipping/payment option with an inset
+ * box-shadow. Theme-6 carries 20% alpha in every palette, so any ring
+ * painted with it composites over the group's own border (same color)
+ * and darkens the shared pixels. Drop the ring; the group border is the
+ * outline and the filled radio dot carries the selected state. */
 .wc-block-components-radio-control--highlight-checked .wc-block-components-radio-control-accordion-option--checked-option-highlighted.wc-block-components-radio-control-accordion-option--checked-option-highlighted,
 .wc-block-components-radio-control--highlight-checked label.wc-block-components-radio-control__option--checked-option-highlighted.wc-block-components-radio-control__option--checked-option-highlighted {
-	box-shadow: inset 0 0 0 1px var(--wp--preset--color--theme-6);
+	box-shadow: none;
 }
 
 /* The boxes around these components are WooCommerce ::after overlays and


### PR DESCRIPTION
## What

Follow-up to #399 (Linear WOOTHME-463). Theme-6 is defined with 20% alpha in every palette (`rgba(17, 17, 17, 0.2)` in the default), so the 1px inset ring on the selected shipping/payment option composited over the group's border, which is now the same color, and the overlapping pixels rendered darker. Since a semi-transparent color can never overlap itself cleanly and an opaque flattened equivalent would need a per-palette value, the ring is removed instead (`box-shadow: none`).

The option group keeps its single theme-6 border as the outline, and the selected state reads through the filled radio dot, as it already did.

## Testing

1. Checkout: the Shipping options and Payment options boxes show a single uniform theme-6 edge on all sides, with no darker segments.
2. With multiple shipping rates, switching selection moves only the radio dot; separators and the outline stay a single shade.
3. Worth a quick look on a dark scheme (e.g. Autumn) where theme-6 is a light 20% alpha and doubling was equally visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)