### PR TITLE
Replace the 404 upsells section with featured products

### DIFF
--- a/purple/templates/404.html
+++ b/purple/templates/404.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0">
 	<!-- wp:pattern {"slug":"purple/hidden-404"} /-->
-	<!-- wp:pattern {"slug":"purple/woocommerce-upsell-products-collection"} /-->
+	<!-- wp:pattern {"slug":"purple/woocommerce-featured-products"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## What

Fixes #326, together with the attribute filter rename already merged in #401.

The 404 template pulled in the upsell products collection, but upsells need a product to relate to, so on a 404 the collection could never resolve and rendered nothing, exactly the dead-end flagged in the issue. The template now uses the existing Featured products pattern instead, one of the two options suggested in the issue discussion; it's a store-level query merchants control by featuring products.

## Testing

1. Visit a non-existent URL on a store with featured products: the 404 page shows the featured products grid under the 404 message.
2. The upsell pattern itself is unchanged and still used where it has product context (single product, cart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)