### PR TITLE
Restore WooCommerce single-product wrapper compatibility

### DIFF
--- a/purple/templates/single-product.html
+++ b/purple/templates/single-product.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"className":"woocommerce product","__wooCommerceIsFirstBlock":true,"__wooCommerceIsLastBlock":true,"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|90"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group woocommerce product"
+<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|90"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group"
 	style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--90)">
 
 	<!-- wp:pattern {"slug":"purple/hidden-single-product"} /-->

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -319,6 +319,9 @@
 					}
 				}
 			},
+			"core/group": {
+				"css": "&.woocommerce.product { margin-block-start: 0; }"
+			},
 			"core/navigation": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-2)"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Purple marks its `<main>` block with WooCommerce internal compatibility attributes and manually assigns the `woocommerce product` classes. WooCommerce treats the marker as evidence that its compatibility layer has already run, so it skips the standard `<div class="woocommerce product">` wrapper.

Extension CSS targeting `.woocommerce div.product` then fails because the classes are carried by `<main>`.

This PR removes the manual classes and compatibility markers, allowing WooCommerce to inject its standard wrapper around the single-product content. It also adds block-scoped custom CSS for `core/group` in `theme.json` to keep that injected wrapper from inheriting Purple's root block gap.

Closes #375.

Linear: [WOOTHME-453](https://linear.app/a8c/issue/WOOTHME-453/purple-opting-out-of-woocommerces-single-product-wrapper-breaks)

### How to test the changes in this Pull Request:

1. Open a single product page.
2. Inspect the rendered markup around the `<main>` element.
3. Confirm WooCommerce renders `<div class="wp-block-group woocommerce product">` around `<main>`.
4. Confirm `.woocommerce div.product` matches the wrapper.
5. Confirm the wrapper's computed `margin-block-start` is `0` and no extra gap appears above the single-product content.

### Verification performed

Tested on the local `onboarding-flow` site with Purple symlinked from this branch. The rendered product page contains WooCommerce's compatibility `<div class="woocommerce product">` directly around the theme's `<main>` element. The new theme.json entry is valid JSON and WordPress compiles it to `:root :where(.wp-block-group.woocommerce.product) { margin-block-start: 0; }`.
