### PR TITLE
Remove custom link underline styles

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -18,15 +18,6 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
    Utilities
    ========================================================================== */
 
-/*
- * Link styles
- * https://github.com/WordPress/gutenberg/issues/42319
- */
-a {
-	text-decoration-thickness: max(0.025em, 1px) !important;
-	text-underline-offset: 0.15em;
-}
-
 /* Add a transition state for buttons. */
 .wp-element-button {
 	transition: border, background-color, color, box-shadow, opacity, filter;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Continues the simplification effort from #405 and #406. This PR removes the global link underline tuning from `style.css`:

```css
a {
	text-decoration-thickness: max(0.025em, 1px) !important;
	text-underline-offset: 0.15em;
}
```

This rule existed because theme.json has no controls for these properties ([Gutenberg #42319](https://github.com/WordPress/gutenberg/issues/42319)). Removing it means links fall back to the browser's default underline thickness and offset, which are slightly thicker and closer to the text with Inter.

| Before | After |
| ----------- | ----------- |
| <img width="1370" height="422" alt="CleanShot 2026-08-11 at 12 43 35@2x" src="https://github.com/user-attachments/assets/34da1d8a-65e4-4f38-acd5-7a96a2888dfa" /> | <img width="1402" height="450" alt="CleanShot 2026-08-11 at 12 44 02@2x" src="https://github.com/user-attachments/assets/68c456e2-a9bd-4019-bd78-a55c2ad73dc0" /> |


### How to test the changes in this Pull Request:

1. Open any page with underlined links (e.g. post content, footer).
2. Verify link underlines render with the browser defaults and nothing else regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)