### PR TITLE
Move text input border color into theme.json

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -50,12 +50,6 @@ a {
    Forms
    ========================================================================== */
 
-/* Default border color for text inputs and textareas across all forms. */
-input:where([type="text"], [type="email"], [type="url"], [type="tel"], [type="number"], [type="password"], [type="search"]),
-textarea {
-	border-color: var(--wp--preset--color--theme-6);
-}
-
 /* WooCommerce's classic form fields (.form-row .input-text, selects,
  * select2) and extensions rendering the same markup (e.g. Gift Cards)
  * read these tokens; WooCommerce defines them 4px/gray on :root. The

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -705,6 +705,11 @@
 				"typography": {
 					"textDecoration": "underline"
 				}
+			},
+			"textInput": {
+				"border": {
+					"color": "var(--wp--preset--color--theme-6)"
+				}
 			}
 		},
 		"spacing": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Continues the simplification effort from #405 to #410. The default form field border color moves from `style.css` into `styles.elements.textInput` in theme.json.

`textInput` is one of the two form elements WordPress 7.0 added to theme.json (this theme already requires 7.0, and #405 uses its sibling `select`). Its core selector is `textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=text],[type=tel],[type=url])`, which covers exactly the same fields as the removed rule. WordPress emits it without the usual `:root :where()` wrapper, so the specificity matches the old rule and existing higher-specificity overrides (checkout components, plugin forms) behave the same.

Verified on a local site: search block input and comment/textarea fields compute `rgba(17, 17, 17, 0.2)` (theme-6), matching `trunk`.

### How to test the changes in this Pull Request:

1. Check bordered text fields across forms: search block, comments form, My Account login, checkout.
2. Verify field borders are the light theme-6 gray, identical to `trunk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)