### PR TITLE
Remove leftover comments in style.css

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -15,10 +15,6 @@ Tags: e-commerce, one-column, two-columns, three-columns, four-columns, wide-blo
 */
 
 /* ==========================================================================
-   Utilities
-   ========================================================================== */
-
-/* ==========================================================================
    Forms
    ========================================================================== */
 
@@ -321,10 +317,6 @@ a.wc-block-components-product-name:hover {
    WooCommerce — Catalog
    ========================================================================== */
 
-/* Catalog sort order select — CSS customizable select (base-select).
- * Continues PR #82 exploration: https://github.com/woocommerce/woo-themes/pull/82
- * Closed/open styles from Figma Dropdown/Default (1:6531) and Dropdown/Open Links (37:1153).
- * Strip native chrome with appearance: none first; opt into base-select for the picker. */
 /* The block renders its own "Sort by" label beside the select; as inline
  * content the label sits on the baseline while the select is middle-aligned,
  * so their text drifts apart vertically. Center both in a flex row. */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Comment-only cleanup after the recent style.css reductions:

* Remove the empty "Utilities" section header. Its three rules were moved into theme.json by #407, #408, and #409, leaving the banner with nothing under it.
* Remove the stale catalog sorting comment paragraph referencing the base-select styling, PR #82, and the Figma dropdown frames. That styling was removed in #405; the remaining rules below it are layout fixes for the label and select row, and their own comments still describe them accurately.

No CSS rules are changed, only comments.

### How to test the changes in this Pull Request:

1. Confirm the diff touches comments and section banners only.
2. Optionally load the Shop page and verify the catalog sorting row is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)