### PR TITLE
Remove logic renaming WooCommerce core pattern category

### DIFF
--- a/purple/functions.php
+++ b/purple/functions.php
@@ -223,30 +223,6 @@ endif;
 
 add_action( 'init', 'purple_register_pattern_categories' );
 
-if ( ! function_exists( 'purple_rename_woocommerce_pattern_category' ) ) :
-	/**
-	 * Rename the "WooCommerce" pattern category to "Shop" in the inserter.
-	 *
-	 * The slug stays "woo-commerce" so patterns categorised under it
-	 * (Purple's and the WC plugin's) don't need re-tagging; only the
-	 * label displayed in the editor changes. Hooked late so it runs
-	 * after WooCommerce's own registration.
-	 */
-	function purple_rename_woocommerce_pattern_category() {
-		$registry = \WP_Block_Pattern_Categories_Registry::get_instance();
-		if ( $registry->is_registered( 'woo-commerce' ) ) {
-			unregister_block_pattern_category( 'woo-commerce' );
-		}
-		register_block_pattern_category(
-			'woo-commerce',
-			array( 'label' => __( 'Shop', 'purple' ) )
-		);
-	}
-
-endif;
-
-add_action( 'init', 'purple_rename_woocommerce_pattern_category', 99 );
-
 if ( ! function_exists( 'purple_styles' ) ) :
 	/**
 	 * Enqueue styles.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOTHME-482.

With https://github.com/woocommerce/woocommerce/pull/67874, we are moving the logic to rename the WooCommerce patterns category from _WooCommerce_ to _Shop_ into core.

### How to test the changes in this Pull Request:

1. Check out this branch in WC core `update/patterns-category-name` (https://github.com/woocommerce/woocommerce/pull/67874).
2. Create a post or page, open the inserter and switch to the _Patterns_ tab.
3. Verify there is a _Shop_ pattern category and there is no _WooCommerce_ category.