### PR TITLE
Update Petunia colors

### DIFF
--- a/purple/styles/colors/petunia.json
+++ b/purple/styles/colors/petunia.json
@@ -13,7 +13,7 @@
 					"slug": "theme-2"
 				},
 				{
-					"color": "#37125f",
+					"color": "#1f0342",
 					"name": "Color 3",
 					"slug": "theme-3"
 				},
@@ -23,7 +23,7 @@
 					"slug": "theme-4"
 				},
 				{
-					"color": "#f7f3fc",
+					"color": "#f2edff",
 					"name": "Color 5",
 					"slug": "theme-5"
 				},
@@ -33,7 +33,7 @@
 					"slug": "theme-6"
 				},
 				{
-					"color": "#8918e5",
+					"color": "#720eec",
 					"name": "Color 7",
 					"slug": "theme-7"
 				}
@@ -50,7 +50,7 @@
 				{
 					"colors": [
 						"#111111",
-						"#f7f3fc"
+						"#f2edff"
 					],
 					"name": "Duotone 2",
 					"slug": "duotone-2"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOTHME-455.

### How to test the changes in this Pull Request:

1. Verify colors match the Figma file: Gum9XNWccPKfkVRFk1Whsp-fi-6515_8577.

Before | After
--- | ---
<img width="1593" height="1341" alt="Captura de pantalla de 2026-08-20 12-49-58" src="https://github.com/user-attachments/assets/b311db31-0099-4a39-b599-a601a387bd3f" /> | <img width="1593" height="1341" alt="Captura de pantalla de 2026-08-20 12-50-01" src="https://github.com/user-attachments/assets/f1a8d4cb-9621-4d04-b704-faec56ae5ac3" />