### PR TITLE
Update Catalog Sorting comments for when to remove the styles

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -315,15 +315,8 @@ a.wc-block-components-product-name:hover {
 
 /* ==========================================================================
    WooCommerce — Catalog
+   @todo remove once https://github.com/woocommerce/woocommerce/pull/68024 ships.
    ========================================================================== */
-
-/* The block renders its own "Sort by" label beside the select; as inline
- * content the label sits on the baseline while the select is middle-aligned,
- * so their text drifts apart vertically. Center both in a flex row. */
-/* The frontend nests label + select in form.woocommerce-ordering; the
- * editor preview renders them inside a Disabled wrapper instead
- * (.components-disabled). Flex every possible parent so the pair centers
- * and gaps identically in either context. */
 .woocommerce.wc-block-catalog-sorting,
 .woocommerce.wc-block-catalog-sorting .components-disabled,
 .woocommerce.wc-block-catalog-sorting form.woocommerce-ordering {
@@ -332,11 +325,6 @@ a.wc-block-components-product-name:hover {
 	gap: 0.3em;
 	margin-bottom: 0;
 }
-
-/* WooCommerce's label rules add bottom and right margins that push the
- * label off-center and double the gap; the flex gap handles spacing. The
- * doubled-class selector beats WooCommerce's editor-only
- * label.orderby-label margin-right rule. */
 .woocommerce.wc-block-catalog-sorting label,
 .woocommerce.wc-block-catalog-sorting.wc-block-catalog-sorting label.orderby-label {
 	margin: 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of WOOTHME-410.

With Catalog Sorting alignment being fixed in https://github.com/woocommerce/woocommerce/pull/68024, we will be able to remove the styles from Purple.

### How to test the changes in this Pull Request:

1. Check out `fix/catalog-sorting-label-alignment` in WooCommerce core (https://github.com/woocommerce/woocommerce/pull/68024).
2. Verify there are no regressions related to the _Catalog Sorting_ label: it's still vertically aligned and it has spacing between the label and the select.
3. Remove all the styles under `WooCommerce — Catalog` section from the Purple CSS file.
4. Verify there are no regressions again.