### PR TITLE
Clean up Chips styles

### DIFF
--- a/purple/style.css
+++ b/purple/style.css
@@ -345,17 +345,6 @@ a.wc-block-components-product-name:hover {
 	gap: var(--wp--preset--spacing--10);
 }
 
-/* Product filter chips expose no typography UI and WooCommerce hardcodes .8em. */
-.wc-block-product-filter-chips__item {
-	border-radius: 0;
-	color: var(--wp--preset--color--theme-2);
-	font-size: var(--wp--preset--font-size--small);
-	letter-spacing: 0.06em;
-	line-height: 1.28;
-	padding: 0.625rem 1.25rem;
-	text-transform: uppercase;
-}
-
 /* Closed accordion panels are server-rendered without [hidden] (the
  * Interactivity API only applies it after hydration), so they flash open
  * on load. Collapse them from first paint via the server-rendered

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -512,6 +512,24 @@
 					"text": "var(--wp--preset--color--theme-2)"
 				}
 			},
+			"woocommerce/product-filter-chips": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"letterSpacing": "0.06em",
+					"textTransform": "uppercase"
+				},
+				"border": {
+					"radius": "0"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "0.625rem",
+						"left": "1.25rem",
+						"right": "1.25rem",
+						"top": "0.625rem"
+					}
+				}
+			},
 			"woocommerce/product-filters": {
 				"css": "--wc-product-filter-block-spacing: 0;"
 			},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Compare the Chips styles in WC `trunk` and Purple `trunk` with the styles in this branch + https://github.com/woocommerce/woocommerce/pull/68105 and verify there are no significant regressions.

Block | Purple on `trunk` and WooCommerce on `trunk` | This branch and https://github.com/woocommerce/woocommerce/pull/68105
--- | --- | ---
Add to Cart + Options | <img width="595" height="628" alt="imatge" src="https://github.com/user-attachments/assets/1e52cca5-8088-4078-ba3e-e7a6cc7f7a44" /> | <img width="595" height="628" alt="imatge" src="https://github.com/user-attachments/assets/05380a0f-e545-41af-83e2-e47a2bab18bb" />
Product Filters | <img width="867" height="1136" alt="imatge" src="https://github.com/user-attachments/assets/73a8722c-590c-4e4c-a26f-de7d7b5db2e9" /> | <img width="867" height="1136" alt="imatge" src="https://github.com/user-attachments/assets/39f15b97-66df-4b81-a2a1-f01ad80f657c" />