### PR TITLE
Add spacing above active product filters

### DIFF
--- a/purple/theme.json
+++ b/purple/theme.json
@@ -492,6 +492,13 @@
 					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
+			"woocommerce/product-filter-active": {
+				"spacing": {
+					"margin": {
+						"top": "var(--wp--preset--spacing--10)"
+					}
+				}
+			},
 			"woocommerce/product-filter-attribute": {
 				"color": {
 					"text": "var(--wp--preset--color--theme-2)"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes [WOOTHME-491](https://linear.app/a8c/issue/WOOTHME-491/add-spacing-to-filter-selections).

Add a top margin using spacing preset `10` to the Active Filters block in `theme.json`, so selected filter chips do not touch the last accordion divider.

### How to test the changes in this Pull Request:

1. Activate Purple with WooCommerce and open the Shop page with products available to filter.
2. Select a filter, such as **In stock**. Confirm there is space between the final accordion divider and the selected filter chips.
3. Select several filters so the chips wrap onto multiple rows. Confirm the space above them remains consistent, including when accordion sections are collapsed.

### Validation performed:

- Theme validation passed: 25 JSON files, 63 patterns, and 172 asset references.
- `git diff --check` passed.
- Desktop browser: confirmed a computed 10px top margin and visually checked two selected chips wrapping onto separate rows.
- Mobile, editor, New Arrivals, and clearing the final selection still need verification.

### Screenshots

| Before | After |
| --- | --- | 
<img width="333" height="394" alt="image" src="https://github.com/user-attachments/assets/94e94a7d-7888-4afe-b8af-8b93bb685817" /> | <img width="340" height="422" alt="image" src="https://github.com/user-attachments/assets/01944942-4e69-44fc-a47e-0d915fc11282" />

