### PR TITLE
Purple: stop unregistering WooCommerce, Jetpack, and WordPress patterns

### DIFF
--- a/purple/functions.php
+++ b/purple/functions.php
@@ -12,7 +12,7 @@ declare( strict_types = 1 );
 
 if ( ! function_exists( 'purple_unregister_patterns' ) ) :
 	/**
-	 * Unregister Jetpack patterns, WooCommerce patterns, and core patterns bundled in WordPress.
+	 * Unregister Jetpack patterns and core patterns bundled in WordPress.
 	 */
 	function purple_unregister_patterns() {
 		$pattern_names = array(
@@ -23,47 +23,6 @@ if ( ! function_exists( 'purple_unregister_patterns' ) ) :
 			'registration-form',
 			'appointment-form',
 			'feedback-form',
-			// WooCommerce patterns. Keep only a curated set in the WooCommerce
-			// inserter category; everything else gets unregistered.
-			'woocommerce-blocks/banner',
-			'woocommerce-blocks/centered-content-with-image-below',
-			'woocommerce-blocks/content-right-with-image-left',
-			'woocommerce-blocks/featured-category-cover-image',
-			'woocommerce-blocks/featured-category-triple',
-			'woocommerce-blocks/footer-large',
-			'woocommerce-blocks/footer-simple-menu',
-			'woocommerce-blocks/footer-with-3-menus',
-			'woocommerce-blocks/four-image-grid-content-left',
-			'woocommerce-blocks/header-centered-menu',
-			'woocommerce-blocks/header-distraction-free',
-			'woocommerce-blocks/header-essential',
-			'woocommerce-blocks/header-large',
-			'woocommerce-blocks/header-minimal',
-			'woocommerce-blocks/heading-with-three-columns-of-content-with-link',
-			'woocommerce-blocks/hero-product-3-split',
-			'woocommerce-blocks/hero-product-chessboard',
-			'woocommerce-blocks/just-arrived-full-hero',
-			'woocommerce-blocks/product-collection-3-columns',
-			'woocommerce-blocks/product-collection-5-columns',
-			'woocommerce-blocks/product-collection-featured-products-5-columns',
-			'woocommerce-blocks/product-query-product-gallery',
-			'woocommerce-blocks/related-products',
-			'woocommerce-blocks/social-follow-us-in-social-media',
-			'woocommerce-blocks/testimonials-3-columns',
-			'woocommerce-blocks/testimonials-single',
-			'woocommerce-blocks/three-columns-with-images-and-content',
-			'woocommerce/coming-soon',
-			'woocommerce/coming-soon-entire-site',
-			'woocommerce/coming-soon-store-only',
-			'woocommerce/no-products-found',
-			'woocommerce/no-products-found-clear-filters',
-			'woocommerce/page-coming-soon-default',
-			'woocommerce/page-coming-soon-image-gallery',
-			'woocommerce/page-coming-soon-minimal-left-image',
-			'woocommerce/page-coming-soon-modern-black',
-			'woocommerce/page-coming-soon-split-right-image',
-			'woocommerce/page-coming-soon-with-header-footer',
-			'woocommerce/product-search-form',
 			// Patterns bundled in WordPress core.
 			// These would be removed by remove_theme_support( 'core-block-patterns' )
 			// if it's called on the init action with priority 9 from a plugin, not from a theme.
@@ -89,11 +48,11 @@ if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
 	/**
 	 * Hide WooCommerce template parts the theme doesn't use from the Site Editor.
 	 *
-	 * Companion to purple_unregister_patterns(): template parts have no
-	 * unregister API — WooCommerce injects them into template queries with its
-	 * own get_block_templates filter (priority 10) — so they are filtered out
-	 * of query results here instead. This only affects listings; rendering a
-	 * template part goes through get_block_file_template and is unaffected.
+	 * Template parts have no unregister API — WooCommerce injects them into
+	 * template queries with its own get_block_templates filter (priority 10) —
+	 * so they are filtered out of query results here instead. This only affects
+	 * listings; rendering a template part goes through get_block_file_template
+	 * and is unaffected.
 	 * Copies customized in the editor have the 'custom' source and are kept,
 	 * so user-edited content is never hidden.
 	 *
@@ -108,9 +67,8 @@ if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
 		}
 
 		$hidden_template_part_slugs = array(
-			// Referenced only by WooCommerce's coming-soon patterns, which
-			// purple_unregister_patterns() removes; Purple ships its own
-			// coming-soon template.
+			// Purple ships its own coming-soon template. WooCommerce's patterns
+			// can still render this part when inserted into a page.
 			'coming-soon-social-links',
 		);
 

--- a/purple/functions.php
+++ b/purple/functions.php
@@ -10,49 +10,6 @@
 
 declare( strict_types = 1 );
 
-if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
-	/**
-	 * Hide WooCommerce template parts the theme doesn't use from the Site Editor.
-	 *
-	 * Template parts have no unregister API — WooCommerce injects them into
-	 * template queries with its own get_block_templates filter (priority 10) —
-	 * so they are filtered out of query results here instead. This only affects
-	 * listings; rendering a template part goes through get_block_file_template
-	 * and is unaffected.
-	 * Copies customized in the editor have the 'custom' source and are kept,
-	 * so user-edited content is never hidden.
-	 *
-	 * @param WP_Block_Template[] $templates     Found templates.
-	 * @param array               $query         Template query arguments.
-	 * @param string              $template_type wp_template or wp_template_part.
-	 * @return WP_Block_Template[]
-	 */
-	function purple_hide_woocommerce_template_parts( array $templates, array $query, string $template_type ): array {
-		if ( 'wp_template_part' !== $template_type ) {
-			return $templates;
-		}
-
-		$hidden_template_part_slugs = array(
-			// Purple ships its own coming-soon template. WooCommerce's patterns
-			// can still render this part when inserted into a page.
-			'coming-soon-social-links',
-		);
-
-		return array_values(
-			array_filter(
-				$templates,
-				static function ( $template ) use ( $hidden_template_part_slugs ) {
-					return 'custom' === $template->source
-						|| ! in_array( $template->slug, $hidden_template_part_slugs, true );
-				}
-			)
-		);
-	}
-
-endif;
-
-add_filter( 'get_block_templates', 'purple_hide_woocommerce_template_parts', 20, 3 );
-
 if ( ! function_exists( 'purple_hide_store_templates_from_template_picker' ) ) :
 	/**
 	 * Keep store templates out of the post editor's "Change template" picker.

--- a/purple/functions.php
+++ b/purple/functions.php
@@ -10,40 +10,6 @@
 
 declare( strict_types = 1 );
 
-if ( ! function_exists( 'purple_unregister_patterns' ) ) :
-	/**
-	 * Unregister Jetpack patterns and core patterns bundled in WordPress.
-	 */
-	function purple_unregister_patterns() {
-		$pattern_names = array(
-			// Jetpack form patterns.
-			'contact-form',
-			'newsletter-form',
-			'rsvp-form',
-			'registration-form',
-			'appointment-form',
-			'feedback-form',
-			// Patterns bundled in WordPress core.
-			// These would be removed by remove_theme_support( 'core-block-patterns' )
-			// if it's called on the init action with priority 9 from a plugin, not from a theme.
-			'core/query-standard-posts',
-			'core/query-medium-posts',
-			'core/query-small-posts',
-			'core/query-grid-posts',
-			'core/query-large-title-posts',
-			'core/query-offset-posts',
-			'core/social-links-shared-background-color',
-		);
-		foreach ( $pattern_names as $pattern_name ) {
-			$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );
-			if ( $pattern ) {
-				unregister_block_pattern( $pattern_name );
-			}
-		}
-	}
-
-endif;
-
 if ( ! function_exists( 'purple_hide_woocommerce_template_parts' ) ) :
 	/**
 	 * Hide WooCommerce template parts the theme doesn't use from the Site Editor.
@@ -147,18 +113,6 @@ if ( ! function_exists( 'purple_setup' ) ) :
 
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
-		// Unregister Jetpack form patterns and core patterns bundled in WordPress.
-		// Simple sites.
-		purple_unregister_patterns();
-		add_filter(
-			'wp_loaded',
-			function () {
-				// Atomic sites.
-				purple_unregister_patterns();
-			}
-		);
-		// Remove theme support for the core and featured patterns coming from the Dotorg pattern directory.
-		remove_theme_support( 'core-block-patterns' );
 	}
 
 endif;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Purple should not remove patterns supplied by WooCommerce, Jetpack, or WordPress. Any cleanup of those patterns should happen in their source projects.

- Remove `purple_unregister_patterns()` and all its calls, including the `wp_loaded` callback.
- Remove `remove_theme_support( 'core-block-patterns' )`, retaining WordPress pattern-directory support.
- Remove `purple_hide_woocommerce_template_parts()` and its filter so the `coming-soon-social-links` template part is available in Site Editor listings.
- Keep `purple_hide_store_templates_from_template_picker()` unchanged: dedicated store templates remain excluded from the post editor’s “Change template” picker.

Related: [WOOTHME-481 — Don't unregister core patterns](https://linear.app/a8c/issue/WOOTHME-481/dont-unregister-core-patterns).

There's equivalent patterns cleanup in Woo core: https://github.com/woocommerce/woocommerce/pull/68132.

### How to test the changes in this Pull Request:

1. Activate Purple and WooCommerce. Activate Jetpack with its form patterns available to test those as well.
2. Open the block editor's pattern inserter. Confirm WordPress query patterns, Jetpack form patterns, and public WooCommerce patterns supplied by the installed versions remain available. Insert representative patterns and confirm they render, e.g.
- Woo: woocommerce-blocks/featured-category-cover-image
- Jetpack: rsvp-form
- Gutenberg: core/query-standard-posts

### Verification performed

- PHP syntax and WordPress Coding Standards checks passed for `purple/functions.php`.
- Theme source validation passed: 25 JSON files, 63 patterns, and 172 asset references.
- On the local onboarding-flow site, verified all six formerly excluded Jetpack form patterns, the WordPress standard query pattern, and all pattern files shipped by the currently linked WooCommerce checkout remain registered.
- Verified core block pattern support is enabled and the unregister function no longer exists.


- Verified `coming-soon-social-links` is returned by template-part queries and the store-template picker filter remains active.
