### PR TITLE
Purple: normalize serialization in catalog template and grid pattern

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -48,7 +48,7 @@
 
 <!-- wp:woocommerce/product-filter-rating -->
 <div class="wp-block-woocommerce-product-filter-rating"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
-<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
+<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"}}}} -->
 <div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
 <h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e( 'Rating', 'purple' );?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->
@@ -68,7 +68,7 @@
 
 <!-- wp:woocommerce/product-filter-attribute -->
 <div class="wp-block-woocommerce-product-filter-attribute"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
-<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
+<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"}}}} -->
 <div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
 <h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e( 'Attribute filter', 'purple' );?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->
@@ -88,7 +88,7 @@
 
 <!-- wp:woocommerce/product-filter-status -->
 <div class="wp-block-woocommerce-product-filter-status"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
-<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":{},"right":{},"left":{}}}} -->
+<div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"}}}} -->
 <div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
 <h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e( 'Status', 'purple' );?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>
 <!-- /wp:accordion-heading -->

--- a/purple/templates/archive-product.html
+++ b/purple/templates/archive-product.html
@@ -8,7 +8,7 @@
 
 		<!-- wp:woocommerce/breadcrumbs /-->
 
-		<!-- wp:query-title {"type":"archive","level":1,"showPrefix":false,"align":"wide"} /-->
+		<!-- wp:query-title {"type":"archive","showPrefix":false,"align":"wide"} /-->
 
 		<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
 		<div class="wp-block-group alignwide"><!-- wp:term-description /--></div>


### PR DESCRIPTION
## What

Two small serialization cleanups so a plain open-and-save of the Product Catalog template in the Site Editor no longer produces a "customized" copy full of phantom diffs (spotted while auditing template customizations on the demo site):

- **`product-grid-with-filters.php`**: remove the empty `top`/`right`/`left` border sides from the three filter accordion items. They carry no styling and round-trip unstably: PHP's block re-serialization (the hooked-blocks pass) converts empty JSON objects to `[]`, so the values flip between `{}` and `[]` on every editor save.
- **`archive-product.html`**: drop `"level":1` from the query-title block; 1 is the block default and the editor strips it on every save.

No rendered output changes in either case.

## Testing

1. Open Appearance > Editor > Templates > Product Catalog and save it without making changes.
2. **Expected:** the resulting DB copy differs from the theme file only in whitespace joining, with no attribute-level diffs.
3. Confirm the catalog page renders identically: archive title is still an H1, filter accordions still show only their bottom borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)