### PR TITLE
Purple: bump Tested up to to WordPress 7.1

### DIFF
--- a/purple/readme.txt
+++ b/purple/readme.txt
@@ -1,7 +1,7 @@
 === Purple ===
 Contributors: Automattic
 Requires at least: 7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 0.0.1
 License: GPLv2 or later

--- a/purple/style.css
+++ b/purple/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Purple is a WooCommerce starter theme made for the Site Editor and modern commerce. Its clean styles and adaptable color system suit any catalog: fashion and clothing, jewelry, beauty, home decor, food and drink, or digital downloads. Commerce-ready templates and curated patterns cover the storefront from product pages and filterable shop views to cart and checkout. Ten color palettes and ten font pairings make it easy to match your brand in a click, and the theme works well with Jetpack blocks, supports RTL languages, and is fully translation-ready. Whether you’re launching your first online store or refreshing an established one, Purple is a versatile foundation for selling with WordPress and WooCommerce.
 Requires at least: 7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Version: 0.0.1
 License: GNU General Public License v2 or later


### PR DESCRIPTION
## What

Two-line metadata bump: `Tested up to: 7.0` becomes `7.1` in `style.css` and `readme.txt`.

`Requires at least` stays at 7.0: the CI matrix validates every PR against WordPress 7.0, and all of the theme's version-gated features (select element styling, navigation overlay, accordion filters, block visibility, post-data bindings) work there. The `latest` CI job and the demo site both run 7.1, which earns the new Tested up to value.

## Testing

- CI green on both the 7.0 and latest (7.1) jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)