### PR TITLE
Make Purple product filters sticky

### DIFF
--- a/purple/patterns/page-new-arrivals.php
+++ b/purple/patterns/page-new-arrivals.php
@@ -31,7 +31,7 @@
 // TODO: Remove the Product Filters spacing override in theme.json once WooCommerce
 // PR #67870 ships: https://github.com/woocommerce/woocommerce/pull/67870.
 ?>
-<!-- wp:woocommerce/product-filters -->
+<!-- wp:woocommerce/product-filters {"style":{"position":{"type":"sticky","top":"var(--wp--preset--spacing--10)"}}} -->
 <div class="wp-block-woocommerce-product-filters wc-block-product-filters"><!-- wp:woocommerce/product-filter-price -->
 <div class="wp-block-woocommerce-product-filter-price"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
 <div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->

--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -25,7 +25,7 @@
 // TODO: Remove the Product Filters spacing override in theme.json once WooCommerce
 // PR #67870 ships: https://github.com/woocommerce/woocommerce/pull/67870.
 ?>
-<!-- wp:woocommerce/product-filters -->
+<!-- wp:woocommerce/product-filters {"style":{"position":{"type":"sticky","top":"var(--wp--preset--spacing--10)"}}} -->
 <div class="wp-block-woocommerce-product-filters wc-block-product-filters"><!-- wp:woocommerce/product-filter-price -->
 <div class="wp-block-woocommerce-product-filter-price"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
 <div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->


### PR DESCRIPTION
## Summary

- Make the Product Filters blocks sticky in Purple’s filtered product-grid patterns
- Depends on Woo core adding position sticky to filters: https://github.com/woocommerce/woocommerce/pull/68256

## Testing

1. Build WooCommerce based on https://github.com/woocommerce/woocommerce/pull/68256
2. Reset Product Catalog template
3. Go to frontend
4. Make sure filters are sticky when scrolling a page

Linear: https://linear.app/a8c/issue/WOOTHME-502/product-filters-block-cant-be-made-sticky-needs-supportspositionsticky