### PR TITLE
Expose Purple storefront pattern in inserter

### DIFF
--- a/purple/patterns/page-storefront.php
+++ b/purple/patterns/page-storefront.php
@@ -2,7 +2,7 @@
 /**
  * Title: Storefront
  * Slug: purple/storefront
- * Inserter: no
+ * Categories: purple
  * Template Types: front-page
  *
  * @package purple

--- a/purple/patterns/page-storefront.php
+++ b/purple/patterns/page-storefront.php
@@ -3,7 +3,8 @@
  * Title: Storefront
  * Slug: purple/storefront
  * Categories: purple
- * Template Types: front-page
+ * Block Types: core/post-content
+ * Post Types: page, wp_template
  *
  * @package purple
  */

--- a/purple/patterns/page-storefront.php
+++ b/purple/patterns/page-storefront.php
@@ -3,8 +3,11 @@
  * Title: Storefront
  * Slug: purple/storefront
  * Categories: purple
+ * Keywords: starter
+ * Description: A shop homepage with hero, new arrivals, product categories, best sellers, posts, testimonials, and store features.
  * Block Types: core/post-content
  * Post Types: page, wp_template
+ * Viewport width: 1440
  *
  * @package purple
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Purple front-page template renders `purple/storefront` as the theme’s default homepage. The pattern was marked `Inserter: no`, which kept it out of the pattern browser and search. As a result, users could not compare the default storefront with the two alternatives or easily restore it after choosing another layout.

This change:

- makes `purple/storefront` available in the inserter
- assigns it to the `purple` category alongside both storefront alternatives
- aligns its pattern metadata with the alternatives, including the starter keyword, description, editor contexts, and preview viewport width

Linear: https://linear.app/a8c/issue/WOOTHME-501/purplestorefront-has-no-pattern-categories

### How to test the changes in this Pull Request:

1. Check out this PR and activate the Purple theme on a WordPress site with WooCommerce active.
2. If the theme was already loaded before checking out the PR, clear its cached pattern headers with `wp eval "wp_get_theme()->delete_pattern_cache();"`.
3. Open the editor for a page or template.
4. Open the block inserter and select **Patterns**.
5. Select the **Purple** category and verify **Storefront**, **Storefront alternative**, and **Storefront alternative 2** are all listed.
6. Search for `storefront` and verify all three patterns appear.
7. Insert **Storefront** and verify the complete default homepage layout is added.