### PR TITLE
Style current navigation items in Purple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: '7.0'
-            core: https://wordpress.org/wordpress-7.0.zip
+          - label: '7.1'
+            core: https://wordpress.org/wordpress-7.1.zip
           - label: latest
             core: https://wordpress.org/latest.zip
 

--- a/purple/phpcs.xml.dist
+++ b/purple/phpcs.xml.dist
@@ -29,5 +29,5 @@
 		</properties>
 	</rule>
 
-	<config name="minimum_wp_version" value="7.0"/>
+	<config name="minimum_wp_version" value="7.1"/>
 </ruleset>

--- a/purple/readme.txt
+++ b/purple/readme.txt
@@ -1,6 +1,6 @@
 === Purple ===
 Contributors: Automattic
-Requires at least: 7.0
+Requires at least: 7.1
 Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 0.0.1

--- a/purple/style.css
+++ b/purple/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/purple
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Purple is a WooCommerce starter theme made for the Site Editor and modern commerce. Its clean styles and adaptable color system suit any catalog: fashion and clothing, jewelry, beauty, home decor, food and drink, or digital downloads. Commerce-ready templates and curated patterns cover the storefront from product pages and filterable shop views to cart and checkout. Ten color palettes and ten font pairings make it easy to match your brand in a click, and the theme works well with Jetpack blocks, supports RTL languages, and is fully translation-ready. Whether you’re launching your first online store or refreshing an established one, Purple is a versatile foundation for selling with WordPress and WooCommerce.
-Requires at least: 7.0
+Requires at least: 7.1
 Tested up to: 7.1
 Requires PHP: 7.4
 Version: 0.0.1

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -347,6 +347,13 @@
 					"blockGap": "var(--wp--preset--spacing--30)"
 				}
 			},
+			"core/navigation-link": {
+				"-current": {
+					"typography": {
+						"textDecoration": "underline"
+					}
+				}
+			},
 			"core/post-comments-form": {
 				"css": "& .comment-form { margin-top: var(--wp--preset--spacing--20); }"
 			},


### PR DESCRIPTION
## Summary

- Raise Purple’s minimum supported WordPress version to 7.1 - @Aljullu , happy to hear your opinion on it. Styling of `-current` item Navigation is only available since WP 7.1. While this is pretty small reason to bump required WordPress version but after giving it some thoughts, I believe it's ok to require the newest WordPress with newest features.
- Add underline for current navigation item.

## Testing

### Automated

- Run `npm run validate:theme -- purple`.
- Confirm Theme CI passes against WordPress 7.1 and latest.

### Manual

1. In the Site Editor, edit the header Navigation block.
2. Add a top-level Page link by selecting an existing page from the link picker. Do not paste a URL or create a Custom Link.
3. Save the navigation and visit the selected page on the front end.
4. Confirm the current item is underlined on desktop and mobile.

Linear: https://linear.app/a8c/issue/WOOTHME-497/navigation-block-ships-no-current-menu-item-styling