### PR TITLE
Purple: Sync front page product collection sizes with carousel patterns

### DIFF
--- a/purple/patterns/woocommerce-best-sellers.php
+++ b/purple/patterns/woocommerce-best-sellers.php
@@ -29,9 +29,9 @@
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0","top":"var:preset|spacing|20"}},"typography":{"lineHeight":"1.18","textAlign":"left"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1.5625"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55","fontStyle":"normal"}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template -->
 
 <!-- wp:woocommerce/product-collection-no-results -->

--- a/purple/patterns/woocommerce-new-arrivals.php
+++ b/purple/patterns/woocommerce-new-arrivals.php
@@ -29,9 +29,9 @@
 <!-- wp:woocommerce/product-sale-badge {"align":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10","right":"var:preset|spacing|10"}}}} /-->
 <!-- /wp:woocommerce/product-image -->
 
-<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0","top":"var:preset|spacing|20"}},"typography":{"lineHeight":"1.18","textAlign":"left"}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1.5625"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"large","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}},"typography":{"lineHeight":"1.55","fontStyle":"normal"}}} /-->
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","left":"0"}}}} /-->
 <!-- /wp:woocommerce/product-template -->
 
 <!-- wp:woocommerce/product-collection-no-results -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the front page, the New arrivals and Best sellers product collections used the `large` font size for both product titles and prices, while the other product collection carousels (Upsell and Related products) use the `medium` title size and the default (medium) price size. The catalog grids (`product-grid-with-filters`, `page-new-arrivals`) already follow the same medium sizing.

This change updates `woocommerce-new-arrivals` and `woocommerce-best-sellers` to match the carousel patterns exactly:

- Product title: `medium` font size with line-height 1.5625 (was `large` with line-height 1.18)
- Product price: inherits the default body size (medium) instead of an explicit `large` with typography overrides

Linear: https://linear.app/a8c/issue/WOOPRD-3744/front-page-product-collections

### Screenshots or screen recordings:

Screenshots show the Best sellers section; New arrivals shares identical product title and price markup.

Before | After
-- | --
<img width="1316" height="353" alt="before-best-sellers" src="https://github.com/user-attachments/assets/44fa8dba-3efc-4c7b-97b7-8d4479d4f7a6" /> | <img width="1316" height="353" alt="after-best-sellers" src="https://github.com/user-attachments/assets/14d32c3d-9d8b-4993-a4b9-76d396d61793" />

### How to test the changes in this Pull Request:

1. Check out this PR and activate the Purple theme on a WordPress site with WooCommerce active and some products.
2. View the front page and scroll to the **New arrivals** and **Best sellers** sections.
3. Verify product titles and prices render at the medium size (16px), matching the **You might also like** and **Frequently bought together** carousels on a single product page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)