### PR TITLE
Purple: Make Petunia the default color palette, rename old default to Cobalt

### DIFF
--- a/purple/styles/colors/cobalt.json
+++ b/purple/styles/colors/cobalt.json
@@ -13,17 +13,17 @@
 					"slug": "theme-2"
 				},
 				{
-					"color": "#1f0342",
+					"color": "#243DC8",
 					"name": "Color 3",
 					"slug": "theme-3"
 				},
 				{
-					"color": "#322f37",
+					"color": "#686868",
 					"name": "Color 4",
 					"slug": "theme-4"
 				},
 				{
-					"color": "#f2edff",
+					"color": "#F7F7F7",
 					"name": "Color 5",
 					"slug": "theme-5"
 				},
@@ -33,7 +33,7 @@
 					"slug": "theme-6"
 				},
 				{
-					"color": "#720eec",
+					"color": "#DC352F",
 					"name": "Color 7",
 					"slug": "theme-7"
 				}
@@ -50,7 +50,7 @@
 				{
 					"colors": [
 						"#111111",
-						"#f2edff"
+						"#F7F7F7"
 					],
 					"name": "Duotone 2",
 					"slug": "duotone-2"
@@ -59,5 +59,5 @@
 		}
 	},
 	"version": 3,
-	"title": "Petunia"
+	"title": "Cobalt"
 }

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -31,17 +31,17 @@
 					"slug": "theme-2"
 				},
 				{
-					"color": "#243DC8",
+					"color": "#1f0342",
 					"name": "Color 3",
 					"slug": "theme-3"
 				},
 				{
-					"color": "#686868",
+					"color": "#322f37",
 					"name": "Color 4",
 					"slug": "theme-4"
 				},
 				{
-					"color": "#F7F7F7",
+					"color": "#f2edff",
 					"name": "Color 5",
 					"slug": "theme-5"
 				},
@@ -51,7 +51,7 @@
 					"slug": "theme-6"
 				},
 				{
-					"color": "#DC352F",
+					"color": "#720eec",
 					"name": "Color 7",
 					"slug": "theme-7"
 				}
@@ -68,7 +68,7 @@
 				{
 					"colors": [
 						"#111111",
-						"#F7F7F7"
+						"#f2edff"
 					],
 					"name": "Duotone 2",
 					"slug": "duotone-2"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following the decision in the Linear thread, this promotes the Petunia palette (updated to the Woo brand colors in #420) from a style variation to the theme default, so new sites and the demo site share the same colors:

- `theme.json` now uses Petunia's colors: deep purple `#1f0342` (theme-3), dark gray-purple `#322f37` (theme-4), lavender `#f2edff` (theme-5), and Woo purple `#720eec` (theme-7), plus the matching duotone.
- The previous default (white, black, cobalt blue `#243DC8`, gray, red accent) is preserved as a new **Cobalt** style variation, keeping the variation count at ten.
- `styles/colors/petunia.json` is removed since it is now identical to the default.

Most visible shifts: buttons and the CTA section go from cobalt blue to deep purple, and sale badges go from red to Woo purple.

Linear: https://linear.app/a8c/issue/WOOTHME-455/review-color-palettes

### Screenshots or screen recordings:

Before | After
-- | --
<img width="1316" height="889" alt="before-hero" src="https://github.com/user-attachments/assets/dfb723c6-1012-4359-97f6-d42bee110f6b" /> | <img width="1316" height="889" alt="after-hero" src="https://github.com/user-attachments/assets/74805298-43be-4ff6-9ce3-d7d9a8a7382c" />
<img width="1316" height="889" alt="before-badges-cta" src="https://github.com/user-attachments/assets/ad0a491d-7ad9-488d-9d00-963d38f39c3c" /> | <img width="1316" height="889" alt="after-badges-cta" src="https://github.com/user-attachments/assets/ab2e643e-ad5f-4a3d-90db-8dbc070746f8" />

### How to test the changes in this Pull Request:

1. Check out this PR and activate the Purple theme on a WordPress site with WooCommerce active.
2. View the front page and verify the default colors are Petunia's: deep purple buttons and CTA section, Woo purple sale badges, lavender section backgrounds.
3. In the Site Editor, open **Styles** and verify ten color variations are listed, including **Cobalt** (the old white/black/blue/gray default) and no separate Petunia entry.
4. Apply Cobalt and verify it restores the previous default look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)