### PR TITLE
Remove duplicate footer in Order Confirmation template

### DIFF
--- a/purple/patterns/hidden-order-confirmation.php
+++ b/purple/patterns/hidden-order-confirmation.php
@@ -62,5 +62,3 @@
 
 <!-- wp:woocommerce/order-confirmation-additional-information /--></main>
 <!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","theme":"purple"} /-->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The footer template part was added to the [`hidden-order-confirmation.php`](https://github.com/woocommerce/woo-themes/blob/ab8b634f6104f441d6e9bf4df8ae775e3626ec66/purple/patterns/hidden-order-confirmation.php#L66) pattern and to the [`order-confirmation.html`](https://github.com/woocommerce/woo-themes/blob/ab8b634f6104f441d6e9bf4df8ae775e3626ec66/purple/templates/order-confirmation.html#L5) template, which caused the footer to appear twice. This PR removes it from the pattern.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Order Confirmation.
2. Verify there is only one footer template part.