### PR TITLE
Add search to mobile navigation overlay

### DIFF
--- a/purple/parts/purple-navigation-overlay-alternative.html
+++ b/purple/parts/purple-navigation-overlay-alternative.html
@@ -32,7 +32,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"purple-mobile-navigation-search","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
 
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>

--- a/purple/parts/purple-navigation-overlay-alternative.html
+++ b/purple/parts/purple-navigation-overlay-alternative.html
@@ -32,9 +32,9 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
 
-		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
+		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/purple/parts/purple-navigation-overlay-alternative.html
+++ b/purple/parts/purple-navigation-overlay-alternative.html
@@ -32,6 +32,8 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"purple-mobile-navigation-search","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>
 	<!-- /wp:group -->

--- a/purple/parts/purple-navigation-overlay-alternative.html
+++ b/purple/parts/purple-navigation-overlay-alternative.html
@@ -32,7 +32,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"}},"textColor":"theme-2"} /-->
 
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>

--- a/purple/parts/purple-navigation-overlay-alternative.html
+++ b/purple/parts/purple-navigation-overlay-alternative.html
@@ -32,7 +32,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"purple-mobile-navigation-search","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
 
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>

--- a/purple/parts/purple-navigation-overlay.html
+++ b/purple/parts/purple-navigation-overlay.html
@@ -12,6 +12,8 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"purple-mobile-navigation-search","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>
 	<!-- /wp:group -->

--- a/purple/parts/purple-navigation-overlay.html
+++ b/purple/parts/purple-navigation-overlay.html
@@ -12,9 +12,9 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
 
-		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
+		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/purple/parts/purple-navigation-overlay.html
+++ b/purple/parts/purple-navigation-overlay.html
@@ -12,7 +12,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"purple-mobile-navigation-search","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
 
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>

--- a/purple/parts/purple-navigation-overlay.html
+++ b/purple/parts/purple-navigation-overlay.html
@@ -12,7 +12,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"purple-mobile-navigation-search","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
 
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","style":{"spacing":{"blockGap":"2.5rem"}},"layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>

--- a/purple/parts/purple-navigation-overlay.html
+++ b/purple/parts/purple-navigation-overlay.html
@@ -12,7 +12,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group"
 		style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"}},"textColor":"theme-2"} /-->
+		<!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"}},"textColor":"theme-2"} /-->
 
 		<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","layout":{"type":"flex","justifyContent":"stretch","orientation":"vertical"}} /-->
 	</div>

--- a/purple/patterns/hidden-header-search.php
+++ b/purple/patterns/hidden-header-search.php
@@ -9,4 +9,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","buttonPosition":"button-only","buttonUseIcon":true,"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+<!-- wp:search {"showLabel":false,"buttonPosition":"button-only","buttonUseIcon":true,"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->

--- a/purple/patterns/hidden-header-search.php
+++ b/purple/patterns/hidden-header-search.php
@@ -9,4 +9,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","buttonPosition":"button-only","buttonUseIcon":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","buttonPosition":"button-only","buttonUseIcon":true,"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->

--- a/purple/patterns/hidden-header-search.php
+++ b/purple/patterns/hidden-header-search.php
@@ -9,4 +9,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","buttonPosition":"button-only","buttonUseIcon":true,"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"border":{"width":"0px","style":"none"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'purple' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'purple' ); ?>","buttonPosition":"button-only","buttonUseIcon":true,"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|theme-2"}}},"color":{"background":"#ffffff00"},"layout":{"selfStretch":"fixed","flexSize":"40px"}},"textColor":"theme-2"} /-->

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -425,8 +425,8 @@
 					"textInput": {
 						"spacing": {
 							"padding": {
-								"left": "12px",
-								"right": "12px"
+								"left": "var:preset|spacing|10",
+								"right": "var:preset|spacing|10"
 							}
 						}
 					}

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -411,7 +411,7 @@
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
 				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; }"
+				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__inside-wrapper { background-color: transparent; }"
 			},
 			"core/separator": {
 				"border": {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -411,7 +411,7 @@
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
 				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__button { padding-right: 12px; }"
+				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__button { padding-right: var(--wp--preset--spacing--10); }"
 			},
 			"core/separator": {
 				"border": {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -411,7 +411,6 @@
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
 				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; }",
 				"elements": {
 					"button": {
 						"spacing": {
@@ -420,6 +419,14 @@
 								"left": "var:preset|spacing|10",
 								"right": "var:preset|spacing|10",
 								"top": "var:preset|spacing|10"
+							}
+						}
+					},
+					"textInput": {
+						"spacing": {
+							"padding": {
+								"left": "12px",
+								"right": "12px"
 							}
 						}
 					}

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -410,6 +410,19 @@
 			"core/search": {
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
+				},
+				"css": "& .wp-block-search__input { padding-inline: 12px; }",
+				"elements": {
+					"button": {
+						"spacing": {
+							"padding": {
+								"bottom": "var:preset|spacing|10",
+								"left": "var:preset|spacing|10",
+								"right": "var:preset|spacing|10",
+								"top": "var:preset|spacing|10"
+							}
+						}
+					}
 				}
 			},
 			"core/separator": {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -411,7 +411,7 @@
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
 				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__inside-wrapper { background-color: transparent; }"
+				"css": "& .wp-block-search__input { padding-inline: 12px; }"
 			},
 			"core/separator": {
 				"border": {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -411,7 +411,7 @@
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
 				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__button { padding-right: 0; }"
+				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__button { padding-right: 12px; }"
 			},
 			"core/separator": {
 				"border": {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -411,7 +411,7 @@
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
 				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; }"
+				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__button { padding-right: 0; }"
 			},
 			"core/separator": {
 				"border": {

--- a/purple/theme.json
+++ b/purple/theme.json
@@ -410,8 +410,7 @@
 			"core/search": {
 				"border": {
 					"color": "var(--wp--preset--color--theme-6)"
-				},
-				"css": "& .wp-block-search__input { padding-inline: 12px; } &.purple-mobile-navigation-search .wp-block-search__button { padding-right: var(--wp--preset--spacing--10); }"
+				}
 			},
 			"core/separator": {
 				"border": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Hide the "button-only" animated header search on tablet and mobile viewports.
- Add a full-width Search block above the links in both Purple mobile navigation overlays.
- Preserve the desktop search treatment in the mobile overlay, including its transparent, borderless icon button and theme colors.
- Style Search input and button spacing via  `theme.json` element styles, removing the custom Search CSS selector.

Flow as per:
<img width="772" height="588" alt="image" src="https://github.com/user-attachments/assets/b2b8d37b-ac50-4bf6-80e0-6c0d96d4d91f" />

### Screenshots or screen recordings:

Before | After
-- | --
https://github.com/user-attachments/assets/507f6563-8f44-42d1-97f7-8cb686a5f87d | https://github.com/user-attachments/assets/feb3c40c-8087-4730-80b4-aad8a2f5118c

### How to test the changes in this Pull Request:

1. At a desktop viewport, confirm the header still displays the compact search icon and that expanding it retains the existing styling.
2. Resize the viewport below 480px and confirm the search icon is absent from the header.
3. Open the mobile navigation and confirm a full-width search input appears above the navigation links.
4. Enter a query and submit it using the search icon; confirm the site search results page loads for that query.
