### PR TITLE
Fix CI with PHP 8.1

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
-	"phpVersion": "7.4",
+	"phpVersion": "8.1",
 	"testsEnvironment": false,
 	"themes": [
 		"./purple",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the wp-env integration environment from PHP 7.4 to PHP 8.1.

The PHP 7.4 WordPress Docker image is based on Debian Bullseye, whose package repositories moved after end of life. This causes wp-env setup to fail before the repository CI jobs run. PHP 8.1 avoids the affected image and aligns these tests with the WooCommerce Core E2E environment.

### How to test the changes in this Pull Request:

CI is green, while it's failing for example here https://github.com/woocommerce/woo-themes/pull/441