### PR TITLE
Add missing spacing between accordions and close button in Product Filters overlay

### DIFF
--- a/purple/patterns/product-grid-with-filters.php
+++ b/purple/patterns/product-grid-with-filters.php
@@ -27,7 +27,7 @@
 ?>
 <!-- wp:woocommerce/product-filters {"style":{"position":{"type":"sticky","top":"var(--wp--preset--spacing--10)"}}} -->
 <div class="wp-block-woocommerce-product-filters wc-block-product-filters"><!-- wp:woocommerce/product-filter-price -->
-<div class="wp-block-woocommerce-product-filter-price"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"}}} -->
+<div class="wp-block-woocommerce-product-filter-price"><!-- wp:accordion {"style":{"spacing":{"blockGap":"0"},"@mobile":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"@tablet":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}}} -->
 <div role="group" class="wp-block-accordion"><!-- wp:accordion-item {"style":{"border":{"bottom":{"color":"var:preset|color|theme-6","width":"1px"},"top":[],"right":[],"left":[]},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
 <div class="wp-block-accordion-item" style="border-bottom-color:var(--wp--preset--color--theme-6);border-bottom-width:1px;margin-top:0;margin-bottom:0"><!-- wp:accordion-heading {"level":4,"style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|10"}}}} -->
 <h4 class="wp-block-accordion-heading has-icon has-icon-right"><button type="button" class="wp-block-accordion-heading__toggle" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--10)"><span class="wp-block-accordion-heading__toggle-title"><?php esc_html_e( 'Price', 'purple' );?></span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h4>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOTHME-507.

### How to test the changes in this Pull Request:

1. Open the Product Filters overlay in the Shop page when on mobile or tablet.
2. Verify there is space between the accordions and the top right close button.

Before | After
--- | ---
<img width="972" height="1041" alt="imatge" src="https://github.com/user-attachments/assets/cfa82db4-a902-4f6b-aaa6-33f4707bf2b0" /> | <img width="972" height="1041" alt="imatge" src="https://github.com/user-attachments/assets/123e1858-4630-4819-a2f0-a0bb7175f0b7" />