### PR TITLE
 Move Single Product reviews CSS to block styles 

### DIFF
--- a/purple/patterns/hidden-single-product.php
+++ b/purple/patterns/hidden-single-product.php
@@ -110,13 +110,13 @@
 <div class="wp-block-woocommerce-product-reviews"><!-- wp:woocommerce/product-reviews-title {"showProductTitle":false,"showReviewsCount":false,"level":3,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"fontSize":"x-large"} /-->
 
 <!-- wp:woocommerce/product-review-template -->
-<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"},"margin":{"top":"0","bottom":"var:preset|spacing|70"}}}} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|20"},"margin":{"top":"0","bottom":"var:preset|spacing|70"}}}} -->
 <div class="wp-block-columns" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:column {"width":"100px"} -->
 <div class="wp-block-column" style="flex-basis:100px"><!-- wp:woocommerce/product-review-author-name {"isLink":false,"style":{"spacing":{"padding":{"bottom":"0","top":"0.25em"}}}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"0"},"@mobile":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/product-review-rating /-->
 
 <!-- wp:woocommerce/product-review-content /--></div>
@@ -124,7 +124,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"140px"} -->
-<div class="wp-block-column" style="flex-basis:140px"><!-- wp:woocommerce/product-review-date {"isLink":false,"style":{"spacing":{"padding":{"bottom":"0","top":"0.25em"}}}} /--></div>
+<div class="wp-block-column" style="flex-basis:140px"><!-- wp:woocommerce/product-review-date {"isLink":false,"style":{"spacing":{"padding":{"bottom":"0","top":"0.25em"}},"@mobile":{"spacing":{"padding":{"top":"0"}}}}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/purple/patterns/hidden-single-product.php
+++ b/purple/patterns/hidden-single-product.php
@@ -110,8 +110,8 @@
 <div class="wp-block-woocommerce-product-reviews"><!-- wp:woocommerce/product-reviews-title {"showProductTitle":false,"showReviewsCount":false,"level":3,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"fontSize":"x-large"} /-->
 
 <!-- wp:woocommerce/product-review-template -->
-<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"},"margin":{"top":"0","bottom":"var:preset|spacing|90"}}}} -->
-<div class="wp-block-columns" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--90)"><!-- wp:column {"width":"100px"} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"},"margin":{"top":"0","bottom":"var:preset|spacing|70"}}}} -->
+<div class="wp-block-columns" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:column {"width":"100px"} -->
 <div class="wp-block-column" style="flex-basis:100px"><!-- wp:woocommerce/product-review-author-name {"isLink":false,"style":{"spacing":{"padding":{"bottom":"0","top":"0.25em"}}}} /--></div>
 <!-- /wp:column -->
 
@@ -137,6 +137,6 @@
 <!-- wp:woocommerce/product-reviews-pagination-next /-->
 <!-- /wp:woocommerce/product-reviews-pagination -->
 
-<!-- wp:woocommerce/product-review-form {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--></div>
+<!-- wp:woocommerce/product-review-form {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /--></div>
 <!-- /wp:woocommerce/product-reviews --></div>
 <!-- /wp:group -->

--- a/purple/style.css
+++ b/purple/style.css
@@ -357,11 +357,6 @@ a.wc-block-components-product-name:hover {
 	}
 }
 
-.wp-block-woocommerce-product-review-content p {
-	margin-top: var(--wp--preset--spacing--20);
-	margin-bottom: 0;
-}
-
 .wp-block-woocommerce-product-gallery-large-image-next-previous-is-layout-flex {
 	gap: 0;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes one more CSS selector and replaces it with styles on the template blocks.

### How to test the changes in this Pull Request:

1. Add a couple of reviews to a product.
2. Verify they look good on desktop and mobile. Styles are not a perfect match to the previous implementation because the responsive sizing depends on the viewport, but they should still look good.

<img width="1495" height="1180" alt="imatge" src="https://github.com/user-attachments/assets/4744b616-edd7-4a00-adbc-0ca46a1d121e" />